### PR TITLE
#20 Enable eLink 1.05 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itokawa",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "private": true,
   "scripts": {

--- a/src/devices/commandStations/elink.spec.ts
+++ b/src/devices/commandStations/elink.spec.ts
@@ -6,7 +6,7 @@ import { createSinonStubInstance, StubbedClass } from "../../utils/testUtils";
 import {  nextTick } from "../../utils/promiseUtils";
 import * as promiseUtils from "../../utils/promiseUtils";
 import { AsyncSerialPort } from "../asyncSerialPort"
-import { ELinkCommandStation, ELinkCommandBatch } from "./elink";
+import { ELinkCommandStation, ELinkCommandBatch, applyChecksum } from "./elink";
 import { CommandStationState } from "./commandStation";
 
 const CONNECTION_STRING = "port=/dev/ttyACM0";
@@ -110,13 +110,13 @@ describe("eLink", () => {
             expect(setTimeoutStub.callCount).to.equal(1);
         })
 
-        it ("should handshake with firmware 1.07", async () => {
+        async function testHandshake(version: number) {
             portReads = [
                 [0x01],
                 [0x02, 0x03],
                 [0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x35],
                 [0x01, 0x04, 0x05],
-                [0x63, 0x21, 0x6B, 0x01, 0x28]
+                applyChecksum([0x63, 0x21, version, 0x01, 0x00]) as number[]
             ];
 
             const cs = await ELinkCommandStation.open(CONNECTION_STRING);
@@ -129,28 +129,10 @@ describe("eLink", () => {
                 [0x35, 0x39, 0x39, 0x39, 0x39, 0x39, 0x0C],
                 [0x21, 0x21, 0x00]
             ]);
-        });
+        }
 
-        it ("should handshake with firmware 1.05", async () => {
-            portReads = [
-                [0x01],
-                [0x02, 0x03],
-                [0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x35],
-                [0x01, 0x04, 0x05],
-                [0x63, 0x21, 0x69, 0x01, 0x2A]
-            ];
-
-            const cs = await ELinkCommandStation.open(CONNECTION_STRING);
-
-            expect(cs.state).to.equal(CommandStationState.IDLE);
-            expect(portReads).to.be.empty;
-            expect(portWrites).to.eql([
-                [0x21, 0x24, 0x05],
-                [0x3A, 0x36, 0x34, 0x4A, 0x4B, 0x44, 0x38, 0x39, 0x42, 0x53, 0x54, 0x39],
-                [0x35, 0x39, 0x39, 0x39, 0x39, 0x39, 0x0C],
-                [0x21, 0x21, 0x00]
-            ]);
-        });
+        it ("should handshake with firmware 1.05", () => testHandshake(0x69));
+        it ("should handshake with firmware 1.07", () => testHandshake(0x6B));
 
         it("should fail if port isn't specified in connection string", async () => {
             await expect(ELinkCommandStation.open("")).to.be.eventually.rejectedWith("\"port\" not specified in connection string");

--- a/src/devices/commandStations/elink.spec.ts
+++ b/src/devices/commandStations/elink.spec.ts
@@ -110,13 +110,34 @@ describe("eLink", () => {
             expect(setTimeoutStub.callCount).to.equal(1);
         })
 
-        it ("should handshake correctly when required", async () => {
+        it ("should handshake with firmware 1.07", async () => {
             portReads = [
                 [0x01],
                 [0x02, 0x03],
                 [0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x35],
                 [0x01, 0x04, 0x05],
                 [0x63, 0x21, 0x6B, 0x01, 0x28]
+            ];
+
+            const cs = await ELinkCommandStation.open(CONNECTION_STRING);
+
+            expect(cs.state).to.equal(CommandStationState.IDLE);
+            expect(portReads).to.be.empty;
+            expect(portWrites).to.eql([
+                [0x21, 0x24, 0x05],
+                [0x3A, 0x36, 0x34, 0x4A, 0x4B, 0x44, 0x38, 0x39, 0x42, 0x53, 0x54, 0x39],
+                [0x35, 0x39, 0x39, 0x39, 0x39, 0x39, 0x0C],
+                [0x21, 0x21, 0x00]
+            ]);
+        });
+
+        it ("should handshake with firmware 1.05", async () => {
+            portReads = [
+                [0x01],
+                [0x02, 0x03],
+                [0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x35],
+                [0x01, 0x04, 0x05],
+                [0x63, 0x21, 0x69, 0x01, 0x2A]
             ];
 
             const cs = await ELinkCommandStation.open(CONNECTION_STRING);

--- a/src/devices/commandStations/elink.ts
+++ b/src/devices/commandStations/elink.ts
@@ -46,7 +46,7 @@ function ensureValidMessage(message: number[], type?:MessageType) {
     if (type && message[0] != type) throw new CommandStationError(`Unexpected message type, expected ${type}, but got ${message[0]}`);
 }
 
-function applyChecksum(message: number[] | Buffer) {
+export function applyChecksum(message: number[] | Buffer) {
     // Interestingly, the eLink doesn't seem to verify checksums and will accept
     // any valid-ish message without complaining.
     let checkSum = 0;
@@ -54,6 +54,8 @@ function applyChecksum(message: number[] | Buffer) {
         checkSum ^= message[i];
 
     message[message.length - 1] = checkSum;
+
+    return message
 }
 
 function updateHandshakeMessage(data: number[]) {
@@ -189,8 +191,7 @@ export class ELinkCommandStation extends CommandStationBase {
             this._cancelHeartbeart();
 
             // Select the CV we want to read from
-            let reqMessage = [MessageType.CV_SELECT_REQUEST, 0x15, cv, 0];
-            applyChecksum(reqMessage);
+            let reqMessage = applyChecksum([MessageType.CV_SELECT_REQUEST, 0x15, cv, 0]);
             await this._port.write(reqMessage);
             await this._ensureCvSelected();
 
@@ -214,8 +215,7 @@ export class ELinkCommandStation extends CommandStationBase {
             this._cancelHeartbeart();
 
             // Select the CV we want to write to
-            let reqMessage = [MessageType.CV_WRITE_REQUEST, 0x16, cv, value, 0];
-            applyChecksum(reqMessage);
+            let reqMessage = applyChecksum([MessageType.CV_WRITE_REQUEST, 0x16, cv, value, 0]);
             await this._port.write(reqMessage);
             await this._ensureCvSelected();
 

--- a/src/devices/commandStations/elink.ts
+++ b/src/devices/commandStations/elink.ts
@@ -27,14 +27,13 @@ enum MessageType {
     LOCO_COMMAND = 0xE4
 }
 
-//const CV_SELECT_ERROR = 0x13;
-
 enum LocoCommand {
     SET_SPEED = 0x13
 }
 
 const SUPPORTED_VERSIONS = new Set([
-    0x6B // 1.07
+    0x69, // 1.05 - Untested by me but reported working (Issue #20)
+    0x6B  // 1.07
 ]);
 
 function ensureValidMessage(message: number[], type?:MessageType) {


### PR DESCRIPTION
Added firmware 1.05 to the list of supported eLink versions.
Made `applyChecksum` an exported function and made it usable inline.