### PR TITLE
Added verbose log level

### DIFF
--- a/src/devices/commandStations/elink.ts
+++ b/src/devices/commandStations/elink.ts
@@ -269,10 +269,10 @@ export class ELinkCommandStation extends CommandStationBase {
     }
 
     private _scheduleHeartbeat() {
-        log.info(`Scheduling next heartbeat in ${Config.heartbeatTime}s`);
+        log.verbose(`Scheduling next heartbeat in ${Config.heartbeatTime}s`);
         this._heartbeatToken = setTimeout(() => {
 
-            log.info("Requesting hearbeat...");
+            log.verbose("Requesting hearbeat...");
             // It's theoretically possible for this event to fire while we're already writing to the port.
             // In this case, abort the request and rely on the current port user to schedule the next
             // heartbeat.
@@ -362,7 +362,7 @@ export class ELinkCommandStation extends CommandStationBase {
         if (data[1] != 0x22 || data[2] != 0x40)
             throw new CommandStationError(`Unrecognised INFO_RESPONSE, got ${toHumanHex(data)}`);
 
-        log.info("Received status OK response");
+        log.verbose("Received status OK response");
     }
 
     private async _sendVersionInfoRequest() {

--- a/src/utils/logger.spec.ts
+++ b/src/utils/logger.spec.ts
@@ -19,6 +19,7 @@ describe("Logger", () => {
         logger.warning("Test warning");
         logger.display("Test display");
         logger.info("Test info");
+        logger.verbose("Test verbose");
         logger.debug("Test debug");
     }
 
@@ -99,6 +100,21 @@ describe("Logger", () => {
         ]);
     });
 
+    it("should log correctly if level is VERBOSE", () => {
+        Logger.logLevel = LogLevel.VERBOSE;
+        let logger = new Logger("Test");
+
+        writeLogs(logger);
+
+        expect(output).to.eql([
+            "2017-02-02T12:51:19.124Z:ERROR:Test: Test error",
+            "2017-02-02T12:51:19.124Z:WARNING:Test: Test warning",
+            "2017-02-02T12:51:19.124Z:DISPLAY:Test: Test display",
+            "2017-02-02T12:51:19.124Z:INFO:Test: Test info",
+            "2017-02-02T12:51:19.124Z:VERBOSE:Test: Test verbose"
+        ]);
+    });
+
     it("should log correctly if level is DEBUG", () => {
         Logger.logLevel = LogLevel.DEBUG;
         let logger = new Logger("Test");
@@ -110,6 +126,7 @@ describe("Logger", () => {
             "2017-02-02T12:51:19.124Z:WARNING:Test: Test warning",
             "2017-02-02T12:51:19.124Z:DISPLAY:Test: Test display",
             "2017-02-02T12:51:19.124Z:INFO:Test: Test info",
+            "2017-02-02T12:51:19.124Z:VERBOSE:Test: Test verbose",
             "2017-02-02T12:51:19.124Z:DEBUG:Test: Test debug"
         ]);
     });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,11 +2,12 @@ import { timestamp } from "../common/time";
 
 export enum LogLevel {
     NONE = 0,
-    ERROR = 1,
-    WARNING = 2,
-    DISPLAY = 3,
-    INFO = 4,
-    DEBUG = 5,
+    ERROR,      // Application errors
+    WARNING,    // Application warnings
+    DISPLAY,    // Messages the user should see but don't indicate errors or warnings
+    INFO,       // User interactions or external events
+    VERBOSE,    // Periodic automatic events
+    DEBUG,      // Everything including packet level logs
 }
 
 type messageBuilder = () => string;
@@ -43,6 +44,7 @@ export class Logger {
     }
 
     debug (message: string | messageBuilder) { this.log(LogLevel.DEBUG, message); }
+    verbose(message: string | messageBuilder) { this.log(LogLevel.VERBOSE, message); }
     info (message: string | messageBuilder) { this.log(LogLevel.INFO, message); }
     display (message: string | messageBuilder) { this.log(LogLevel.DISPLAY, message); }
     warning (message: string | messageBuilder) { this.log(LogLevel.WARNING, message); }


### PR DESCRIPTION
Verbose log level can now be used for spammy events such as heartbeat messages.