### PR TITLE
Added debug snapshots of serial port activity to investigate short circuiting errors

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -166,8 +166,10 @@ class Application {
 
             log.error("Command station error");
             log.error(err.stack);
-            log.info(`Schedulling retry in ${DEVICE_RETRY_TIME}ms`);
-            setTimeout(() => this._initDevice(), DEVICE_RETRY_TIME);
+
+            const retryTime = this.config.getAs("application.deviceRetryTime", DEVICE_RETRY_TIME);
+            log.info(`Schedulling retry in ${retryTime}ms`);
+            setTimeout(() => this._initDevice(), retryTime);
         };
 
         try {

--- a/src/devices/asyncSerialPort.spec.ts
+++ b/src/devices/asyncSerialPort.spec.ts
@@ -228,6 +228,7 @@ describe("AsyncSerialPort", () => {
 
     describe("saveDebugSanpshot", () => {
         let applicationConfigStub: SinonStub;
+        let applicationGetDataPathStub: SinonStub;
         let writeFileSyncStub: SinonStub;
         let timestampStub: SinonStub;
         let timestampCount = 0;
@@ -239,6 +240,7 @@ describe("AsyncSerialPort", () => {
             config = new ConfigNode();
 
             applicationConfigStub = stub(application, "config").value(config);
+            applicationGetDataPathStub = stub(application, "getDataPath").returns("data/serialport.snapshot.txt");
             writeFileSyncStub = stub(fs, "writeFileSync");
             timestampStub = stub(time, "timestamp").callsFake(() => {
                 return `${timestampCount++}`;
@@ -250,6 +252,7 @@ describe("AsyncSerialPort", () => {
 
         afterEach(() => {
             applicationConfigStub.restore();
+            applicationGetDataPathStub.restore();
             writeFileSyncStub.restore();
             timestampStub.restore();
 
@@ -294,7 +297,7 @@ describe("AsyncSerialPort", () => {
 
             port.saveDebugSanpshot();
             expect(writeFileSyncStub.callCount).to.equal(1);
-            expect(writeFileSyncStub.lastCall.args).to.eql(["serialport.snapshot.txt",
+            expect(writeFileSyncStub.lastCall.args).to.eql(["data/serialport.snapshot.txt",
 "4: Sent: 01 02 03\n\
 5: Recv: 04 05 06\n\
 6: Sent: 07 08 09\n\
@@ -305,6 +308,7 @@ describe("AsyncSerialPort", () => {
 11: Recv: 16 17 18\n\
 12: Sent: 19 1a 1b\n\
 13: Recv: 1c 1d 1e"]);
+            expect(applicationGetDataPathStub.lastCall.args).to.eql(["serialport.snapshot.txt"]);
         })
 
         it("should write the configured number of entires if port debugging is enabled", async () => {
@@ -335,11 +339,12 @@ describe("AsyncSerialPort", () => {
 
             port.saveDebugSanpshot();
             expect(writeFileSyncStub.callCount).to.equal(1);
-            expect(writeFileSyncStub.lastCall.args).to.eql(["serialport.snapshot.txt",
+            expect(writeFileSyncStub.lastCall.args).to.eql(["data/serialport.snapshot.txt",
 "10: Sent: 13 14 15\n\
 11: Recv: 16 17 18\n\
 12: Sent: 19 1a 1b\n\
 13: Recv: 1c 1d 1e"]);
+            expect(applicationGetDataPathStub.lastCall.args).to.eql(["serialport.snapshot.txt"]);
         })
     })
 });

--- a/src/devices/asyncSerialPort.ts
+++ b/src/devices/asyncSerialPort.ts
@@ -44,7 +44,7 @@ export class AsyncSerialPort extends EventEmitter {
 
         if (application.config.has("debug.serialport") && !_debugSnapshot) {
             const size = application.config.getAs("debug.serialport.snapshotsize", 10);
-            log.info(() => `Enabling debug snap shots, size = ${size}`);
+            log.info(() => `Enabling debug snap shots, size=${size}`);
             _debugSnapshot = new DebugSnapshot(size, (data) => {
                 const dataString = typeof(data[1]) === "string" ? data[1] : toHumanHex(data[1]);
                 return `${data[0]}: ${dataString}`;

--- a/src/devices/asyncSerialPort.ts
+++ b/src/devices/asyncSerialPort.ts
@@ -34,6 +34,7 @@ export class AsyncSerialPort extends EventEmitter {
 
         if (application.config.has("debug.serialport")) {
             const size = application.config.get("debug.serialport.snapshotsize", 10) as number;
+            log.info(() => `Enabling debug snap shots, size = ${size}`);
             this._debugSnapshot = new DebugSnapshot(size, (data) => {
                 return `${data[0]}: ${toHumanHex(data[1])}`;
             });
@@ -111,6 +112,7 @@ export class AsyncSerialPort extends EventEmitter {
     saveDebugSanpshot() {
         if (this._debugSnapshot) {
             const path = application.getDataPath("serialport.snapshot.txt");
+            log.info(() => `Saving debug snap shot to ${path}`);
             this._debugSnapshot.save(path);
         }
     }

--- a/src/devices/asyncSerialPort.ts
+++ b/src/devices/asyncSerialPort.ts
@@ -109,6 +109,9 @@ export class AsyncSerialPort extends EventEmitter {
     }
 
     saveDebugSanpshot() {
-        if (this._debugSnapshot) this._debugSnapshot.save("serialport.snapshot.txt");
+        if (this._debugSnapshot) {
+            const path = application.getDataPath("serialport.snapshot.txt");
+            this._debugSnapshot.save(path);
+        }
     }
 }

--- a/src/devices/asyncSerialPort.ts
+++ b/src/devices/asyncSerialPort.ts
@@ -33,7 +33,7 @@ export class AsyncSerialPort extends EventEmitter {
         super();
 
         if (application.config.has("debug.serialport")) {
-            const size = application.config.get("debug.serialport.snapshotsize", 10) as number;
+            const size = application.config.getAs("debug.serialport.snapshotsize", 10);
             log.info(() => `Enabling debug snap shots, size = ${size}`);
             this._debugSnapshot = new DebugSnapshot(size, (data) => {
                 return `${data[0]}: ${toHumanHex(data[1])}`;

--- a/src/devices/commandStations/elink.spec.ts
+++ b/src/devices/commandStations/elink.spec.ts
@@ -149,6 +149,7 @@ describe("eLink", () => {
             portReads.push([0x63, 0x21, 0x6A, 0x01, 0x29]);
             await expect(ELinkCommandStation.open(CONNECTION_STRING)).to.be.eventually.rejectedWith("Unsupported eLink version encountered, version=106");
             expect(serialPortStub.close.callCount).to.equal(1);
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
         })
 
         it("should fail if unexpected message type received", async () => {
@@ -158,6 +159,7 @@ describe("eLink", () => {
             ];
             await expect(ELinkCommandStation.open(CONNECTION_STRING)).to.be.eventually.rejectedWith("Unrecognised message type, got 123");
             expect(serialPortStub.close.callCount).to.equal(1);
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
         })
 
         it("should raise an error if info message checksum is invalid", async () => {
@@ -168,6 +170,7 @@ describe("eLink", () => {
 
             await expect(ELinkCommandStation.open(CONNECTION_STRING)).to.be.eventually.rejectedWith("Invalid checksum for received message");
             expect(serialPortStub.close.callCount).to.equal(1);
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
         })
 
         it("should raise an error if unexpected handshake exchange message received", async () => {
@@ -179,6 +182,7 @@ describe("eLink", () => {
 
             await expect(ELinkCommandStation.open(CONNECTION_STRING)).to.be.eventually.rejectedWith("Unexpected message type, expected 53, but got 54");
             expect(serialPortStub.close.callCount).to.equal(1);
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
         })
 
         it("should raise an error if unexpected handshake complete message received", async () => {
@@ -191,6 +195,7 @@ describe("eLink", () => {
 
             await expect(ELinkCommandStation.open(CONNECTION_STRING)).to.be.eventually.rejectedWith("Handshake failed");
             expect(serialPortStub.close.callCount).to.equal(1);
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
         })
     })
 
@@ -255,6 +260,7 @@ describe("eLink", () => {
 
             expect(handler.callCount).to.equal(1);
             expect(handler.lastCall.args[0].message).to.equal("Mock Error Event");
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
 
             // Verify that an errored port can be closed to release resources
             expect(serialPortStub.close.callCount).to.equal(0);
@@ -302,6 +308,7 @@ describe("eLink", () => {
             expect(onError.callCount).to.equal(1);
             expect(onError.lastCall.args[0].message).to.equal("Mock Write Error");
             expect(cs.state).to.equal(CommandStationState.ERROR);
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
         })
 
         it("should fire error event on unrecognised response to heartbeat", async () => {
@@ -318,6 +325,7 @@ describe("eLink", () => {
             expect(onError.callCount).to.equal(1);
             expect(onError.lastCall.args[0].message).to.equal("Unrecognised message type, got 97");
             expect(cs.state).to.equal(CommandStationState.ERROR);
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
         })
 
         it("should fire error event if info response doesn't contrain expected first value", async () => {
@@ -335,6 +343,7 @@ describe("eLink", () => {
             expect(onError.callCount).to.equal(1);
             expect(onError.lastCall.args[0].message).to.equal("Unrecognised INFO_RESPONSE, got 62 23 40 01");
             expect(cs.state).to.equal(CommandStationState.ERROR);
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
         })
 
         it("should fire error event if info response doesn't contrain expected second value", async () => {
@@ -352,6 +361,7 @@ describe("eLink", () => {
             expect(onError.callCount).to.equal(1);
             expect(onError.lastCall.args[0].message).to.equal("Unrecognised INFO_RESPONSE, got 62 22 41 01");
             expect(cs.state).to.equal(CommandStationState.ERROR);
+            expect(serialPortStub.saveDebugSanpshot.callCount).to.equal(1);
         })
     })
 

--- a/src/devices/commandStations/elink.ts
+++ b/src/devices/commandStations/elink.ts
@@ -6,7 +6,6 @@ import { toHumanHex } from "../../utils/hex";
 import { parseConnectionString } from "../../utils/parsers";
 import { padLeadingZero } from "../../utils/padding";
 import { timeout } from "../../utils/promiseUtils";
-import { registerHandlers } from "../../server/handlers/lifecycle";
 
 const log = new Logger("eLink");
 

--- a/src/utils/debugSnapshot.spec.ts
+++ b/src/utils/debugSnapshot.spec.ts
@@ -1,0 +1,132 @@
+import { expect } from "chai";
+import "mocha";
+import { stub, SinonStub } from "sinon";
+
+import * as fs from "fs";
+import * as time from "../common/time";
+import { DebugSnapshot } from "./debugSnapshot";
+
+describe("DebugSnapshot", () => {
+    describe("Construct", () => {
+        it("should accept valid paramters", () => {
+            new DebugSnapshot(4, stub());
+        })
+
+        it("should reject invalid max snapshot size (zero)", () => {
+            expect(() => new DebugSnapshot(0, stub())).to.throw("Max number of entries must be positive");
+        })
+
+        it("should reject invalid max snapshot size (negative)", () => {
+            expect(() => new DebugSnapshot(-1, stub())).to.throw("Max number of entries must be positive");
+        })
+
+        it("should reject null formatter", () => {
+            expect(() => new DebugSnapshot(1, null)).to.throw("Formatter must not be null");
+        })
+    })
+
+    describe("Add and save", () => {
+        let writeFileSyncStub: SinonStub;
+        let timestampStub: SinonStub;
+        let timestampCount = 0;
+
+        function formatter(data: any[]) {
+            const line: string[] = [];
+            line.push('<');
+            line.push(`${data[0]}`);
+            for (let i = 1; i < data.length; i++) {
+                line.push(" - ");
+                line.push(`${data[i]}`);
+            }
+            line.push('>');
+            return line.join("");
+        }
+
+        beforeEach(() => {
+            writeFileSyncStub = stub(fs, "writeFileSync");
+            timestampStub = stub(time, "timestamp").callsFake(() => {
+                return `${timestampCount++}`;
+            });
+            timestampCount = 0;
+        })
+
+        afterEach(() => {
+            writeFileSyncStub.restore();
+            timestampStub.restore();
+        })
+
+        it("should write an empty file is no items", () => {
+            const snapshot = new DebugSnapshot(4, formatter);
+            
+            snapshot.save("test1.txt");
+
+            expect(writeFileSyncStub.callCount).to.equal(1);
+            expect(writeFileSyncStub.lastCall.args).to.eql(["test1.txt", ""]);
+        })
+
+        it("should write an file containing available data if fewer than max entries added", () => {
+            const snapshot = new DebugSnapshot(4, formatter);
+            
+            snapshot.add("a");
+            snapshot.add("b");
+            snapshot.save("test2.txt");
+
+            expect(writeFileSyncStub.callCount).to.equal(1);
+            expect(writeFileSyncStub.lastCall.args).to.eql(["test2.txt", "0: <a>\n1: <b>"]);
+        })
+
+        it("should write an file all data if max entries added", () => {
+            const snapshot = new DebugSnapshot(4, formatter);
+            
+            snapshot.add("c");
+            snapshot.add("d");
+            snapshot.add("e");
+            snapshot.add("f");
+            snapshot.save("test3.txt");
+
+            expect(writeFileSyncStub.callCount).to.equal(1);
+            expect(writeFileSyncStub.lastCall.args).to.eql(["test3.txt", "0: <c>\n1: <d>\n2: <e>\n3: <f>"]);
+        })
+
+        it("should write an file with most recent data if max entries exceeded", () => {
+            const snapshot = new DebugSnapshot(4, formatter);
+            
+            snapshot.add("g");
+            snapshot.add("h");
+            snapshot.add("i");
+            snapshot.add("j");
+            snapshot.add("k");
+            snapshot.add("l");
+            snapshot.save("test4.txt");
+
+            expect(writeFileSyncStub.callCount).to.equal(1);
+            expect(writeFileSyncStub.lastCall.args).to.eql(["test4.txt", "2: <i>\n3: <j>\n4: <k>\n5: <l>"]);
+        })
+
+        it("should write an file with most recent data if max entries exceeded", () => {
+            const snapshot = new DebugSnapshot(4, formatter);
+            
+            snapshot.add("g");
+            snapshot.add("h");
+            snapshot.add("i");
+            snapshot.add("j");
+            snapshot.add("k");
+            snapshot.add("l");
+            snapshot.save("test4.txt");
+
+            expect(writeFileSyncStub.callCount).to.equal(1);
+            expect(writeFileSyncStub.lastCall.args).to.eql(["test4.txt", "2: <i>\n3: <j>\n4: <k>\n5: <l>"]);
+        })
+
+        it("should handle multiple data args", () => {
+            const snapshot = new DebugSnapshot(4, formatter);
+            
+            snapshot.add("a", "b");
+            snapshot.add("c", "d", "e");
+            snapshot.save("test5.txt");
+
+            expect(writeFileSyncStub.callCount).to.equal(1);
+            expect(writeFileSyncStub.lastCall.args).to.eql(["test5.txt", "0: <a - b>\n1: <c - d - e>"]);
+        })
+    })
+})

--- a/src/utils/debugSnapshot.ts
+++ b/src/utils/debugSnapshot.ts
@@ -1,5 +1,8 @@
 import * as fs from "fs";
 import { timestamp } from "../common/time";
+import { Logger } from "./logger";
+
+const log = new Logger("DebugSnapshot");
 
 type EntryFormatter = (data: any[])=>string;
 
@@ -32,6 +35,7 @@ export class DebugSnapshot {
     }
 
     save(filename: string) {
+        log.info(() => `Saving ${filename}...`);
         const filedata: string[] = [];
         for (const entry of this._entries) {
             filedata.push(entry.format(this._formatter));

--- a/src/utils/debugSnapshot.ts
+++ b/src/utils/debugSnapshot.ts
@@ -1,0 +1,42 @@
+import * as fs from "fs";
+import { timestamp } from "../common/time";
+
+type EntryFormatter = (data: any[])=>string;
+
+class DebugEntry {
+    timestamp: string;
+    constructor(public data: any[]) {
+        this.timestamp = timestamp();
+    }
+
+    format(formatter: EntryFormatter): string {
+        return `${this.timestamp}: ${formatter(this.data)}`;
+    }
+}
+
+export class DebugSnapshot {
+    private readonly _entries: DebugEntry[] = [];
+
+    constructor(private readonly _maxEntries: number, private readonly _formatter: EntryFormatter) {
+        if (_maxEntries <= 0) throw new Error("Max number of entries must be positive");
+        if (!_formatter) throw new Error("Formatter must not be null");
+    }
+
+    add(...data: any[]) {
+        const debugEntry = new DebugEntry(data);
+        while (this._entries.length >= this._maxEntries) {
+            this._entries.shift();
+        }
+
+        this._entries.push(debugEntry);
+    }
+
+    save(filename: string) {
+        const filedata: string[] = [];
+        for (const entry of this._entries) {
+            filedata.push(entry.format(this._formatter));
+        }
+
+        fs.writeFileSync(filename, filedata.join("\n"));
+    }
+}


### PR DESCRIPTION
Added a new DebugSnapshot class.
AsyncSerialPort uses a DebugSnapshot to record recent serial port activity.
Serial port debugging can be enabled in config.xml by adding an xml/debug/serialport node.
Device retry time can be configured in config.xml by setting the xml/application/deviceRetryTime node.