### PR TITLE
Add speed controls to loco panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itokawa",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "itokawa",
-  "version": "0.2.3",
-  "description": "",
+  "version": "0.2.4",
+  "description": "DCC Train Control",
   "private": true,
   "scripts": {
     "start": "node dist/server/main.js",
@@ -13,7 +13,7 @@
     "dev-update": "git pull && npm install && npm run build && npm test",
     "prod-update": "git pull && npm install && npm run build"
   },
-  "author": "",
+  "author": "Adrian O'Grady",
   "license": "MIT",
   "devDependencies": {
     "@serialport/list": "^8.0.7",

--- a/src/client/controls/trainControl.html
+++ b/src/client/controls/trainControl.html
@@ -7,4 +7,9 @@
         data-id="medium">2</button><button
         data-id="fast">3</button></span><input data-id="speed" type="range" min="0" max="127" value="0"/>
     </div>
+    <div data-id="expandedControls" class="expandedControls"><button
+        data-id="decSpeed">-</button><div class="speedDisplay"><span
+        data-id="speedDisplay" class="forward">0</span></div><button
+        data-id="incSpeed">+</button>
+    </div>
 </div>

--- a/src/client/controls/trainControl.ts
+++ b/src/client/controls/trainControl.ts
@@ -14,8 +14,12 @@ export class TrainControl extends ControlBase {
     private _directionButton: HTMLButtonElement;
     private _speedSlider: HTMLInputElement;
 
+    private _speedDisplay: HTMLElement;
+    private readonly _maxSpeed: number;
+
     constructor (parent: HTMLElement, readonly loco: Loco, private readonly _expanded = false) {
         super();
+        this._maxSpeed = loco.discrete ? loco.speeds[2] : loco.maxSpeed;
         this._init(parent);
     }
 
@@ -24,6 +28,8 @@ export class TrainControl extends ControlBase {
 
         const title = getById(control, "title");
         if (this._expanded) {
+            // We don't need the title in expanded mode as we are most likely on the loco panel
+            // page which has its own title for the loco
             title.parentNode.removeChild(title);
         }
         else {
@@ -35,6 +41,7 @@ export class TrainControl extends ControlBase {
         this._directionButton.onclick = () => {
             this._reverse = !this._reverse;
             this._directionButton.innerText = this._reverse ? "REV" : "FWD";
+            this._updateSpeedDisplay();
             this._sendRequest();
         };
 
@@ -42,6 +49,7 @@ export class TrainControl extends ControlBase {
             const button = getById(control, id);
             button.onclick = () => {
                 this._speed = speed;
+                this._updateSpeedDisplay();
                 this._sendRequest();
             };
         };
@@ -58,8 +66,20 @@ export class TrainControl extends ControlBase {
             this._speedSlider.max = `${this.loco.maxSpeed}`;
             this._speedSlider.onchange = () => {
                 this._speed = parseInt(this._speedSlider.value);
+                this._updateSpeedDisplay();
                 this._sendRequest();
             }
+            this._speedSlider.oninput = () => this._updateSpeedDisplay();
+        }
+
+        const expandedControls = getById(control, "expandedControls");
+        if (this._expanded) {
+            this._speedDisplay = getById(control, "speedDisplay");
+            getById(control, "incSpeed").onclick = () => this._incSpeed();
+            getById(control, "decSpeed").onclick = () => this._decSpeed();
+        }
+        else {
+            expandedControls.parentNode.removeChild(expandedControls);
         }
 
         return control;
@@ -68,7 +88,7 @@ export class TrainControl extends ControlBase {
     updateSpeed(speed: number, reverse: boolean) {
         this._speed = speed;
         this._reverse = reverse;
-        this._updateSpeed();
+        this._updateSpeedUi();
     }
 
     private _animateSlider(frames: number) {
@@ -91,21 +111,45 @@ export class TrainControl extends ControlBase {
                 if (frames !== 0)
                     requestAnimationFrame(sliderUpdate);
             }
+            this._updateSpeedDisplay();
         };
         sliderUpdate();
     }
 
-    private _updateSpeed() {
+    private _updateSpeedUi() {
         // We always have a direction button
         this._directionButton.innerText = this._reverse ? "REV" : "FWD";        
 
         // We won't have a slider if we're using discrete speeds
         const slider = this._speedSlider;
-        if (!slider) return;
+        if (!slider) {
+            this._updateSpeedDisplay();
+            return;
+        }
 
         const uiSpeed = parseInt(this._speedSlider.value);
         if (uiSpeed != this._speed)
             this._animateSlider(20);
+    }
+
+    private _updateSpeedDisplay() {
+        if (!this._speedDisplay) return;
+
+        if (this._speedSlider) {
+            this._speedDisplay.innerText = this._speedSlider.value;
+        }
+        else {
+            this._speedDisplay.innerText = `${this._speed}`;
+        }
+
+        if (this._reverse) {
+            this._speedDisplay.classList.remove("forward");
+            this._speedDisplay.classList.add("reverse");
+        }
+        else {
+            this._speedDisplay.classList.add("forward");
+            this._speedDisplay.classList.remove("reverse");
+        }
     }
 
     private _sendRequest() {
@@ -119,5 +163,19 @@ export class TrainControl extends ControlBase {
     private _openLocoPanel() {
         nav.open(LocoPanelConstructor.path, this.loco);
         return false;
+    }
+
+    private _incSpeed() {
+        if (this._speed >= this._maxSpeed) return;
+        this._speed++;
+        this._speedDisplay.innerText = `${this._speed}`;
+        this._sendRequest();
+    }
+
+    private _decSpeed() {
+        if (this._speed <= 0) return;
+        this._speed--;
+        this._speedDisplay.innerText = `${this._speed}`;
+        this._sendRequest();
     }
 }

--- a/src/client/controls/trainControl.ts
+++ b/src/client/controls/trainControl.ts
@@ -14,7 +14,7 @@ export class TrainControl extends ControlBase {
     private _directionButton: HTMLButtonElement;
     private _speedSlider: HTMLInputElement;
 
-    constructor (parent: HTMLElement, readonly loco: Loco) {
+    constructor (parent: HTMLElement, readonly loco: Loco, private readonly _expanded = false) {
         super();
         this._init(parent);
     }
@@ -23,8 +23,13 @@ export class TrainControl extends ControlBase {
         const control = parseHtml(html);
 
         const title = getById(control, "title");
-        title.innerText = this.loco.name;
-        title.onclick = () => this._openLocoPanel();
+        if (this._expanded) {
+            title.parentNode.removeChild(title);
+        }
+        else {
+            title.innerText = this.loco.name;
+            title.onclick = () => this._openLocoPanel();
+        }
 
         this._directionButton = getById(control, "direction");
         this._directionButton.onclick = () => {

--- a/src/client/pages/locoPanel.html
+++ b/src/client/pages/locoPanel.html
@@ -1,7 +1,7 @@
 <div class = "locoPanel container">
     <div data-id="trainTitle" class="title"></div>
     <div class="pageContent">
-        <div data-id="speedContainer"></div>
+        <div data-id="speedContainer" class="speedContainer"></div>
         <hr/>
         <div data-id="functionsContainer"></div>
     </div>

--- a/src/client/pages/locoPanel.html
+++ b/src/client/pages/locoPanel.html
@@ -1,6 +1,8 @@
 <div class = "locoPanel container">
     <div data-id="trainTitle" class="title"></div>
     <div class="pageContent">
+        <div data-id="speedContainer"></div>
+        <hr/>
         <div data-id="functionsContainer"></div>
     </div>
 </div>

--- a/src/client/pages/locoPanel.ts
+++ b/src/client/pages/locoPanel.ts
@@ -3,14 +3,16 @@ import * as prompt from "../controls/promptControl";
 import { parseHtml, getById } from "../utils/dom";
 import { Loco, FunctionMode } from "../../common/api";
 import { FunctionControl } from "../controls/functionControl";
-import { TransportMessage, RequestType, LocoFunctionRequest, FunctionAction, LocoFunctionRefreshRequest } from "../../common/messages";
+import { TransportMessage, RequestType, LocoFunctionRequest, FunctionAction, LocoFunctionRefreshRequest, LocoSpeedRequest } from "../../common/messages";
 import { client } from "../client";
+import { TrainControl } from "../controls/trainControl";
 const html = require("./locoPanel.html");
 
 export class LocoPanelPage extends Page {
     path: string = LocoPanelConstructor.path;
     content: HTMLElement;
     private readonly _loco: Loco;
+    private _speedControl: TrainControl;
     private readonly _functionControls = new Map<number, FunctionControl>();
     private _messageHandlerToken: any;
 
@@ -26,6 +28,9 @@ export class LocoPanelPage extends Page {
         const page = parseHtml(html);
 
         getById(page, "trainTitle").innerText = this._loco.name;
+        const speedContainer = getById(page, "speedContainer");
+        this._speedControl = new TrainControl(speedContainer, this._loco, true);
+
         const functionsContainer = getById(page, "functionsContainer");
         for (const config of this._loco.functions || []) {
             if (config.mode === FunctionMode.NotSet) continue;
@@ -39,8 +44,20 @@ export class LocoPanelPage extends Page {
     }
 
     private _onMessage(message: TransportMessage) {
-        if (message.type !== RequestType.LocoFunction) return;
-        this._updateFunction(message.data as LocoFunctionRequest);
+        switch (message.type) {
+            case RequestType.LocoSpeed:
+                this._updateSpeed(message.data as LocoSpeedRequest);
+                return;
+
+            case RequestType.LocoFunction:
+                this._updateFunction(message.data as LocoFunctionRequest);
+                return;
+        }
+    }
+
+    private _updateSpeed(request: LocoSpeedRequest) {
+        if (request.locoId !== this._loco.address) return;
+        this._speedControl.updateSpeed(request.speed, request.reverse);
     }
 
     private _updateFunction(request: LocoFunctionRequest) {
@@ -59,6 +76,16 @@ export class LocoPanelPage extends Page {
             }
             if (response.lastMessage) return; // The last message is just "OK"
             this._updateFunction(response.data as LocoFunctionRequest);
+        });
+        client.connection.request(RequestType.LocoSpeedRefresh, {
+            locoId: this._loco.address
+        } as LocoFunctionRefreshRequest, (err, response) => {
+            if (err) {
+                prompt.error(`Failed to refresh loco speed:\n${err.message}`);
+                return;
+            }
+            if (response.lastMessage) return; // The last message is just "OK"
+            this._updateSpeed(response.data as LocoSpeedRequest);
         });
     }
 

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -14,7 +14,9 @@ export function parseHtml(content: string): HTMLElement {
 }
 
 export function getById<T extends HTMLElement>(element: HTMLElement, id: string): T {
-    return element.querySelector(`[data-id="${id}"]`);
+    const result = element.querySelector(`[data-id="${id}"]`) as T;
+    if (!result) throw new Error(`Unable to find element with data-id "${id}"`)
+    return result;
 }
 
 export function vaildateNotEmptyInput(input: HTMLInputElement, message: string) {

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -23,6 +23,10 @@ export interface LocoSpeedRequest {
     reverse: boolean
 }
 
+export interface LocoSpeedRefreshRequest {
+    locoId?: number
+}
+
 export enum FunctionAction {
     Trigger = 0,
     LatchOn = 1,

--- a/src/server/handlers/loco.spec.ts
+++ b/src/server/handlers/loco.spec.ts
@@ -485,7 +485,7 @@ describe("Loco Handler", () => {
             }]);
         })
 
-        it("should report 0 and forwards if the loco hasn't been seen", async () => {
+        it("should report 0 forwards speed if the loco hasn't been seen", async () => {
             const handler = getHandler(RequestType.LocoSpeedRefresh);
             await handler({ locoId: 8 }, senderStub);
 

--- a/src/server/handlers/loco.spec.ts
+++ b/src/server/handlers/loco.spec.ts
@@ -378,7 +378,7 @@ describe("Loco Handler", () => {
     })
 
     describe("onLocoSpeedRefresh", () => {
-        it("should report all seen locomotives", async () => {
+        it("should report all seen locomotives if no locoId is provided", async () => {
             await setLocoSpeed(7, 50, true);
             await setLocoSpeed(8, 55);
             resetCommandStation();
@@ -408,6 +408,95 @@ describe("Loco Handler", () => {
                     data: {
                         locoId: 8,
                         speed: 55,
+                        reverse: false
+                    }
+                }
+            ]);
+            expect(senderStub.lastCall.args).to.eql([{
+                lastMessage: true,
+                data: "OK"
+            }]);
+        })
+
+        it("should report all seen locomotives if the request data is null", async () => {
+            await setLocoSpeed(7, 50, true);
+            await setLocoSpeed(8, 55);
+            resetCommandStation();
+            clientBroadcastStub.resetHistory();
+
+            const handler = getHandler(RequestType.LocoSpeedRefresh);
+            await handler(null, senderStub);
+
+            // Verify no commands were sent to the command station
+            expect(commandStationStub.beginCommandBatch.callCount).to.equal(0);
+
+            // Verify client is notified of current speed
+            expect(senderStub.callCount).to.equal(3);
+            expect(senderStub.getCall(0).args).to.eql([
+                {
+                    lastMessage: false,
+                    data: {
+                        locoId: 7,
+                        speed: 50,
+                        reverse: true
+                    }
+                }
+            ]);
+            expect(senderStub.getCall(1).args).to.eql([
+                {
+                    lastMessage: false,
+                    data: {
+                        locoId: 8,
+                        speed: 55,
+                        reverse: false
+                    }
+                }
+            ]);
+            expect(senderStub.lastCall.args).to.eql([{
+                lastMessage: true,
+                data: "OK"
+            }]);
+        })
+
+        it("should report only the loco specified if a locoId is provided", async () => {
+            await setLocoSpeed(7, 50);
+            await setLocoSpeed(8, 55, true);
+            resetCommandStation();
+            clientBroadcastStub.resetHistory();
+
+            const handler = getHandler(RequestType.LocoSpeedRefresh);
+            await handler({ locoId: 8 }, senderStub);
+
+            // Verify client is notified of current speed
+            expect(senderStub.callCount).to.equal(2);
+            expect(senderStub.getCall(0).args).to.eql([
+                {
+                    lastMessage: false,
+                    data: {
+                        locoId: 8,
+                        speed: 55,
+                        reverse: true
+                    }
+                }
+            ]);
+            expect(senderStub.lastCall.args).to.eql([{
+                lastMessage: true,
+                data: "OK"
+            }]);
+        })
+
+        it("should report 0 and forwards if the loco hasn't been seen", async () => {
+            const handler = getHandler(RequestType.LocoSpeedRefresh);
+            await handler({ locoId: 8 }, senderStub);
+
+            // Verify client is notified of current speed
+            expect(senderStub.callCount).to.equal(2);
+            expect(senderStub.getCall(0).args).to.eql([
+                {
+                    lastMessage: false,
+                    data: {
+                        locoId: 8,
+                        speed: 0,
                         reverse: false
                     }
                 }

--- a/static/index.css
+++ b/static/index.css
@@ -490,6 +490,15 @@ a:visited {
     background-color: lightgreen;
 }
 
+.locoPanel .speedContainer {
+    margin-top: 1.0em;
+}
+
+.locoPanel hr {
+    margin-top: 1.0em;
+    margin-bottom: 1.0em;
+}
+
 
 /*
  * QR Code Control

--- a/static/index.css
+++ b/static/index.css
@@ -438,6 +438,44 @@ a:visited {
     width: calc(60% - 1em);
 }
 
+.trainControl .expandedControls {
+    margin-top: 4px;
+}
+
+.trainControl .speedDisplay {
+    display: inline-block;
+    text-align: center;
+    vertical-align: top;
+    margin-left: 2px;
+    margin-right: 2px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    width: calc(60% - 6px);
+    height: calc(2.5em + 1px);
+
+    border-color: rgb(118, 118, 118);
+    border-style: solid;
+    border-width: 1px;
+    background-color: lightgray;
+    line-height: calc(2.5em + 1px);
+}
+
+.trainControl .speedDisplay > span.forward {
+    color: darkgreen;
+}
+
+.trainControl .speedDisplay > span.reverse {
+    color: darkred;
+}
+
+.trainControl .speedDisplay > span {
+    display: inline-block;
+    vertical-align: middle;
+    height: 100%;
+    font-size: x-large;
+    font-weight: bold;
+}
+
 
 /*
  * Loco Control Panel


### PR DESCRIPTION
Speed controls now support an expanded mode that show their current speed setting and single speed step increment/decrement.
Loco speed refresh request can now request speed for a single loco.

Closes #33.