### PR TITLE
Added Feature Flag Support

### DIFF
--- a/src/client/apiClient.ts
+++ b/src/client/apiClient.ts
@@ -60,10 +60,18 @@ export class ApiClient implements IApiClient {
     }
 
     ensureIdle(): Promise<void> {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
+            const start = new Date();
             const check = () => {
                 if (this.isBusy) {
-                    window.requestAnimationFrame(check);
+                    const timeMs = new Date().getTime() - start.getTime();
+                    if (timeMs < 30000) {
+                        // Allow a tick of the event loop before checking again
+                        window.requestAnimationFrame(check);
+                    }
+                    else {
+                        reject(new Error("Timed out waiting for previous request to complete"));
+                    }
                 }
                 else {
                     resolve();

--- a/src/client/apiClient.ts
+++ b/src/client/apiClient.ts
@@ -59,8 +59,18 @@ export class ApiClient implements IApiClient {
         return this.pathRoot + path;
     }
 
-    ensureIdle() {
-        if (this.isBusy) throw new Error("API client is currently busy");
+    ensureIdle(): Promise<void> {
+        return new Promise((resolve) => {
+            const check = () => {
+                if (this.isBusy) {
+                    window.requestAnimationFrame(check);
+                }
+                else {
+                    resolve();
+                }
+            };
+            check();
+        });
     }
 
     private registerAwaiter<T>(resolve: (value:T)=>void, reject: (erro:Error)=>void) {
@@ -74,8 +84,8 @@ export class ApiClient implements IApiClient {
         };
     }
 
-    private request<T>(method: string, path: string, data?: any): Promise<T> {
-        this.ensureIdle();
+    private async request<T>(method: string, path: string, data?: any): Promise<T> {
+        await this.ensureIdle();
         return new Promise((resolve, reject) => {
             try {
                 path = this.getFullPath(path);
@@ -90,6 +100,10 @@ export class ApiClient implements IApiClient {
                 reject(err);
             }
         });
+    }
+
+    getConfig() {
+        return this.request("GET", "/config");
     }
 
     getLocos(): Promise<api.Loco[]> {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -6,8 +6,10 @@ import * as api from "../common/api";
 import * as messages from "../common/messages";
 import { IBindable } from "./utils/bindable";
 import { CommandStationState } from "../devices/commandStations/commandStation";
+import { FeatureFlags } from "../common/featureFlags";
 
 export interface IApiClient {
+    getConfig(): Promise<api.Config>;
     getLocos(): Promise<api.Loco[]>;
     addLoco(name: string, address: number, speed: number[] | number, functions: api.FunctionConfig[], cvs: api.CvMap): Promise<api.Loco>;
     getLoco(id: number): Promise<api.Loco>;
@@ -40,6 +42,7 @@ export interface ICommandConnection extends IBindable{
 export class Client {
     readonly connection: ICommandConnection;
     readonly api: IApiClient;
+    readonly featureFlags: FeatureFlags = new FeatureFlags();
 
     constructor() {
         if (window.location.search === "?demo") {
@@ -50,6 +53,13 @@ export class Client {
             this.connection = new CommandConnection("/control/v1");
             this.api = new ApiClient("/api/v1");
         }
+
+        this.api.getConfig().then((config) => {
+            if (config.features) this.featureFlags.set(config.features);
+        }, (err) => {
+            console.error("Failed to retrieve client config");
+            console.error(err);
+        })
     }
 }
 

--- a/src/client/demo/demoApiClient.ts
+++ b/src/client/demo/demoApiClient.ts
@@ -22,6 +22,10 @@ export class DemoApiClient implements IApiClient {
         this._loadData();
     }
 
+    getConfig() {
+        return Promise.resolve({});
+    }
+
     getLocos(): Promise<api.Loco[]> {
         return Promise.resolve(this._locos);
     }

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -23,3 +23,8 @@ export interface Loco {
     functions?: FunctionConfig[],
     cvs?: CvMap;
 }
+
+export interface Config {
+    client?: any;
+    features?: string[]
+}

--- a/src/common/featureFlags.spec.ts
+++ b/src/common/featureFlags.spec.ts
@@ -11,6 +11,15 @@ describe("Feature Flags", () => {
             flags.set("foo");
         })
 
+        it("should accept an array for strings", () => {
+            const flags = new FeatureFlags();
+            flags.set(["a", "b", "c"]);
+
+            expect(flags.isSet("a")).to.be.true;
+            expect(flags.isSet("b")).to.be.true;
+            expect(flags.isSet("c")).to.be.true;
+        })
+
         it("should reject an empty string", () => {
             const flags = new FeatureFlags();
             expect(() => flags.set("")).to.throw('Invalid flag name, "" is not a valid string');
@@ -78,7 +87,7 @@ describe("Feature Flags", () => {
             const set = new Set(itor);
             expect(set.size).to.equal(2);
             expect(set.has("foo")).to.be.true;
-            expect(set.has("bar")).to.be.true;
+            expect(set).to.contain("bar");
         })
     })
 })

--- a/src/common/featureFlags.spec.ts
+++ b/src/common/featureFlags.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from "chai";
+import "mocha";
+
+import {FeatureFlags } from "./featureFlags";
+
+
+describe("Feature Flags", () => {
+    describe("set", () => {
+        it("should accept a valid string", () => {
+            const flags = new FeatureFlags();
+            flags.set("foo");
+        })
+
+        it("should reject an empty string", () => {
+            const flags = new FeatureFlags();
+            expect(() => flags.set("")).to.throw('Invalid flag name, "" is not a valid string');
+        })
+
+        it("should reject a null value", () => {
+            const flags = new FeatureFlags();
+            expect(() => flags.set(null)).to.throw('Invalid flag name, "null" is not a valid string');
+        })
+
+        it("should reject an undefined value", () => {
+            const flags = new FeatureFlags();
+            expect(() => flags.set(undefined)).to.throw('Invalid flag name, "undefined" is not a valid string');
+        })
+
+        it("should reject a numeric value", () => {
+            const flags = new FeatureFlags();
+            expect(() => flags.set(12 as any)).to.throw('Invalid flag name, "12" is not a valid string');
+        })
+    })
+
+    describe("isSet", () => {
+        it("should report true for only set flags", () => {
+            const flags = new FeatureFlags();
+            flags.set("bar");
+
+            expect(flags.isSet("foo")).to.be.false;
+            expect(flags.isSet("bar")).to.be.true;
+        })
+
+        it("should reject an empty string", () => {
+            const flags = new FeatureFlags();
+            expect(() => flags.isSet("")).to.throw('Invalid flag name, "" is not a valid string');
+        })
+
+        it("should reject a null value", () => {
+            const flags = new FeatureFlags();
+            expect(() => flags.isSet(null)).to.throw('Invalid flag name, "null" is not a valid string');
+        })
+
+        it("should reject an undefined value", () => {
+            const flags = new FeatureFlags();
+            expect(() => flags.isSet(undefined)).to.throw('Invalid flag name, "undefined" is not a valid string');
+        })
+
+        it("should reject a numeric value", () => {
+            const flags = new FeatureFlags();
+            expect(() => flags.isSet(12 as any)).to.throw('Invalid flag name, "12" is not a valid string');
+        })
+    })
+
+    describe("getFlags", () => {
+        it("should return an empty iterator if no flags set", () => {
+            const flags = new FeatureFlags();
+            const itor = flags.getFlags();
+            expect(itor.next()).to.eql({ value: undefined, done: true });
+        })
+
+        it("should return only flags that have been see", () => {
+            const flags = new FeatureFlags();
+            flags.set("foo");
+            flags.set("bar");
+
+            const itor = flags.getFlags();
+            const set = new Set(itor);
+            expect(set.size).to.equal(2);
+            expect(set.has("foo")).to.be.true;
+            expect(set.has("bar")).to.be.true;
+        })
+    })
+})

--- a/src/common/featureFlags.ts
+++ b/src/common/featureFlags.ts
@@ -6,9 +6,15 @@ function enusureValidFlag(flag: string) {
 export class FeatureFlags {
     private readonly _flags = new Set<string>();
 
-    set(flag: string) {
-        enusureValidFlag(flag);
-        this._flags.add(flag);
+    set(flag: string | string[]) {
+        if (Array.isArray(flag)) {
+            for (const f of flag)
+                this.set(f);
+        }
+        else {
+            enusureValidFlag(flag);
+            this._flags.add(flag);
+        }
     }
 
     isSet(flag: string) {

--- a/src/common/featureFlags.ts
+++ b/src/common/featureFlags.ts
@@ -1,0 +1,22 @@
+function enusureValidFlag(flag: string) {
+    if (!flag || typeof(flag) !== "string")
+        throw new Error(`Invalid flag name, "${flag}" is not a valid string`);
+}
+
+export class FeatureFlags {
+    private readonly _flags = new Set<string>();
+
+    set(flag: string) {
+        enusureValidFlag(flag);
+        this._flags.add(flag);
+    }
+
+    isSet(flag: string) {
+        enusureValidFlag(flag);
+        return this._flags.has(flag);
+    }
+
+    getFlags() {
+        return this._flags.values();
+    }
+}

--- a/src/devices/commandStations/elink.spec.ts
+++ b/src/devices/commandStations/elink.spec.ts
@@ -510,7 +510,7 @@ describe("eLink", () => {
             ]);
 
             expect(promiseTimeoutStub.callCount).to.equal(1);
-            expect(promiseTimeoutStub.lastCall.args).to.eql([1]);
+            expect(promiseTimeoutStub.lastCall.args).to.eql([0.3]);
         })
 
         it("should not attempt to process raw function requests", async () => {

--- a/src/devices/commandStations/elink.ts
+++ b/src/devices/commandStations/elink.ts
@@ -11,7 +11,7 @@ const log = new Logger("eLink");
 
 let Config = {
     heartbeatTime: 5,
-    triggerDuration: 1, // seconds
+    triggerDuration: 0.3, // seconds
 }
 
 enum MessageType {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -39,10 +39,6 @@ async function main()
     const ews = expressWs(express());
     const app = ews.app;
 
-    /*app.get("/", (req, res) => {
-        res.send("<h1>Hello World</h1>");
-    });*/
-
     app.ws("/control/v1", getControlWebSocketRoute());
     app.use("/api/v1", (await getRouter()));
     app.use(express.static("static"));

--- a/src/server/routers/apiRouter.ts
+++ b/src/server/routers/apiRouter.ts
@@ -1,6 +1,7 @@
 import { Logger } from "../../utils/logger";
 import * as express from "express";
 import * as api from "../../common/api";
+import * as config from "./configRoutes";
 import { application } from "../../application";
 import { LocoRepository } from "../../model/locoRepository";
 import expressWs = require("express-ws");
@@ -90,6 +91,8 @@ _apiRouter.route("/locos/:id")
         next(err);
     }
 });
+
+config.registerRoutes(_apiRouter, log);
 
 export async function getRouter(): Promise<expressWs.Router> {
     _locoRepo = await application.database.openRepository(LocoRepository);

--- a/src/server/routers/configRoutes.ts
+++ b/src/server/routers/configRoutes.ts
@@ -1,0 +1,29 @@
+import * as express from "express";
+import { application } from "../../application";
+import { Logger } from "../../utils/logger";
+import { Config } from "../../common/api";
+
+export function registerRoutes(router: express.Router, log: Logger) {
+    router.route("/config")
+    .get(async (_req, res, next) => {
+        try {
+            log.info("Requesting config...");
+            const config: Config = {};
+
+            if (application.config.has("client")) config.client = application.config.get("client");
+
+            const flags = [];
+            for (const flag of application.featureFlags.getFlags())
+                flags.push(flag);
+            if (flags.length)
+                config.features = flags;
+
+            res.json(config);
+        }
+        catch (err) {
+            log.error("GET /config failed")
+            log.error(err.stack);
+            next(err);
+        }
+    })
+}

--- a/src/server/serverFeatureFlags.spec.ts
+++ b/src/server/serverFeatureFlags.spec.ts
@@ -1,0 +1,110 @@
+import { expect } from "chai";
+import "mocha";
+
+import { ServerFeatureFlags } from "./serverFeatureFlags";
+import { ConfigNode } from "../utils/config";
+
+describe("Server Feature Flags", () => {
+    describe("setFRomCommandLine", () => {
+        it("should support a single flag", () => {
+            const flags = new ServerFeatureFlags();
+            flags.setFromCommandLine("bar");
+
+            const current = new Set(flags.getFlags());
+            expect(current.size).to.eql(1);
+            expect(current).to.contain("bar");
+        })
+
+        it("should support multiple flags (comma separated)", () => {
+            const flags = new ServerFeatureFlags();
+            flags.setFromCommandLine("bar,foo,,baz");
+
+            const current = new Set(flags.getFlags());
+            expect(current.size).to.eql(3);
+            expect(current).to.contain("foo");
+            expect(current).to.contain("bar");
+            expect(current).to.contain("baz");
+        })
+
+        it("should support multiple flags (space separated)", () => {
+            const flags = new ServerFeatureFlags();
+            flags.setFromCommandLine("bar foo  baz");
+
+            const current = new Set(flags.getFlags());
+            expect(current.size).to.eql(3);
+            expect(current).to.contain("foo");
+            expect(current).to.contain("bar");
+            expect(current).to.contain("baz");
+        })
+
+        it("should support multiple flags (mixed)", () => {
+            const flags = new ServerFeatureFlags();
+            flags.setFromCommandLine("baz, bar foo");
+
+            const current = new Set(flags.getFlags());
+            expect(current.size).to.eql(3);
+            expect(current).to.contain("foo");
+            expect(current).to.contain("bar");
+            expect(current).to.contain("baz");
+        })
+
+        it("should reject an empty string", () => {
+            const flags = new ServerFeatureFlags();
+            expect(() => flags.setFromCommandLine("")).to.throw('Invalid flag definitions, ""');
+        })
+
+        it("should reject a null string", () => {
+            const flags = new ServerFeatureFlags();
+            expect(() => flags.setFromCommandLine(null)).to.throw('Invalid flag definitions, "null"');
+        })
+
+        it("should reject an undefined string", () => {
+            const flags = new ServerFeatureFlags();
+            expect(() => flags.setFromCommandLine(undefined)).to.throw('Invalid flag definitions, "undefined"');
+        })
+
+        it("should reject non-string values", () => {
+            const flags = new ServerFeatureFlags();
+            expect(() => flags.setFromCommandLine(4 as any)).to.throw('Invalid flag definitions, "4"');
+        })
+    })
+
+    describe("setFromConfig", () => {
+        it("should accept an empty node", () => {
+            const config = new ConfigNode();
+            const flags = new ServerFeatureFlags();
+            flags.setFromConfig(config);
+
+            const current = new Set(flags.getFlags());
+            expect(current.size).to.eql(0);
+        })
+
+        it("should accept a node with values", () => {
+            const config = new ConfigNode();
+            config.set("foo", "");
+            config.set("bar", new ConfigNode());
+            const flags = new ServerFeatureFlags();
+            flags.setFromConfig(config);
+
+            const current = new Set(flags.getFlags());
+            expect(current.size).to.eql(2);
+            expect(current).to.contain("foo");
+            expect(current).to.contain("bar");
+        })
+
+        it("should reject a null config", () => {
+            const flags = new ServerFeatureFlags();
+            expect(() => flags.setFromConfig(null)).to.throw("No config provided");            
+        })
+
+        it("should reject a undefined config", () => {
+            const flags = new ServerFeatureFlags();
+            expect(() => flags.setFromConfig(undefined)).to.throw("No config provided");            
+        })
+
+        it("should reject a non-config value", () => {
+            const flags = new ServerFeatureFlags();
+            expect(() => flags.setFromConfig("config" as any)).to.throw("No config provided");            
+        })
+    })
+})

--- a/src/server/serverFeatureFlags.ts
+++ b/src/server/serverFeatureFlags.ts
@@ -1,0 +1,20 @@
+import { FeatureFlags } from "../common/featureFlags";
+import { ConfigNode } from "../utils/config";
+
+export class ServerFeatureFlags extends FeatureFlags {
+    setFromConfig(config: ConfigNode) {
+        if (!(config instanceof ConfigNode)) throw new Error("No config provided");
+
+        for (const flag of config.keys())
+            this.set(flag);
+    }
+
+    setFromCommandLine(flags: string) {
+        if (!flags || typeof(flags) !== "string")
+            throw new Error(`Invalid flag definitions, "${flags}"`);
+
+        for (const flag of flags.split(/[\s\,]/))
+            if (flag)
+                this.set(flag);
+    }
+}

--- a/src/utils/commandLineArgs.spec.ts
+++ b/src/utils/commandLineArgs.spec.ts
@@ -21,10 +21,11 @@ describe("Command Line args", () => {
             commandLineArgs.addCommonOptions(commander as CommanderStatic);
 
             expect(commander["version"].lastCall.args).to.eql([ pjson.version ]);
-            expect(options.size).to.equal(3);
+            expect(options.size).to.equal(4);
             expect(options).to.contain("-d --device <device>");
             expect(options).to.contain("-c --connection-string <connectionString>");
             expect(options).to.contain("--log-level <loglevel>");
+            expect(options).to.contain("--features <feature flags>");
         })
     })
 

--- a/src/utils/commandLineArgs.ts
+++ b/src/utils/commandLineArgs.ts
@@ -5,9 +5,10 @@ let pjson = require('../../package.json');
 export function addCommonOptions(commander: CommanderStatic) {
     commander
         .version(pjson.version)
-        .option("-d --device <device>", "Device type to open.")
-        .option("-c --connection-string <connectionString>", "Connection configuration string.")
-        .option("--log-level <loglevel>", "Log level");
+        .option("-d --device <device>", "Device type to open")
+        .option("-c --connection-string <connectionString>", "Connection configuration string")
+        .option("--log-level <loglevel>", "Log level")
+        .option("--features <feature flags>", "Pre-release feature flags");
 }
 
 export function applyLogLevel(commander: CommanderStatic) {

--- a/src/utils/config.spec.ts
+++ b/src/utils/config.spec.ts
@@ -251,6 +251,25 @@ describe("Config", () => {
                 expect(node.has("foo.bar.baz")).to.be.true;
             })
         })
+
+        describe("keys", () => {
+            it("should return an emptry itorator if node is empty", () => {
+                const node = new ConfigNode();
+                const itor = node.keys();
+                expect(itor.next()).to.eql({ value: undefined, done: true });
+            })
+
+            it("should return an itorator over set items", () => {
+                const node = new ConfigNode();
+                node.set("foo", "test");
+                node.set("bar.baz", "test");
+
+                const set = new Set(node.keys());
+                expect(set.size).to.equal(2);
+                expect(set).to.contain("foo");
+                expect(set).to.contain("bar");
+            })
+        })
     })
 
     describe("loadConfig", () => {

--- a/src/utils/config.spec.ts
+++ b/src/utils/config.spec.ts
@@ -253,13 +253,13 @@ describe("Config", () => {
         })
 
         describe("keys", () => {
-            it("should return an emptry itorator if node is empty", () => {
+            it("should return an emptry iterator if node is empty", () => {
                 const node = new ConfigNode();
                 const itor = node.keys();
                 expect(itor.next()).to.eql({ value: undefined, done: true });
             })
 
-            it("should return an itorator over set items", () => {
+            it("should return an iterator over set items", () => {
                 const node = new ConfigNode();
                 node.set("foo", "test");
                 node.set("bar.baz", "test");

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -21,6 +21,12 @@ export class ConfigNode {
         return this.get(path, defaultValue) as T;
     }
 
+    *keys(): IterableIterator<string> {
+        for (const key of Object.getOwnPropertyNames(this)) {
+            yield key;
+        }
+    }
+
     private _get(path: string[], defaultValue?: Value): Value {
         const key = path.shift();
         if (!(key in this)) return defaultValue;


### PR DESCRIPTION
Added ability to add and check feature flags so that I can experiment with new features without having to make them live.
Feature flags can be defined on the command line or in the config file.
The client is able to request the current feature flags via a new /config API.
Decreased the active duration of triggered functions.
Added ability to query set keys on a ConfigNode.