### PR TITLE
Fix #43 - Support configuring functions on new loco

### DIFF
--- a/src/client/pages/cvEditor.ts
+++ b/src/client/pages/cvEditor.ts
@@ -23,6 +23,9 @@ export class CvEditorPage extends Page {
         const c = {};
         this._cvControls.forEach((cv, key) => c[key] = cv.value);
         if (this._manufacturer && this._version) {
+            // We don't want to set the manufacturer or version if they've not been set
+            // to prevent the train editor page for prompting us to save if there are
+            // no CVs.
             c[8] = this._manufacturer;
             c[7] = this._version;
         }

--- a/src/client/pages/cvEditor.ts
+++ b/src/client/pages/cvEditor.ts
@@ -22,8 +22,10 @@ export class CvEditorPage extends Page {
     get cvs(): CvMap {
         const c = {};
         this._cvControls.forEach((cv, key) => c[key] = cv.value);
-        c[8] = this._manufacturer;
-        c[7] = this._version;
+        if (this._manufacturer && this._version) {
+            c[8] = this._manufacturer;
+            c[7] = this._version;
+        }
         return c;
     }
 

--- a/src/client/pages/trainEditor.ts
+++ b/src/client/pages/trainEditor.ts
@@ -69,39 +69,45 @@ export class TrainEditPage extends Page {
 
     onEnter(previousPage: Page) {
         super.onEnter(previousPage);
-        if (this._id) this._api.getLoco(this._id).then((loco) => {
-            this._nameElement.value = loco.name;
-            this._addressElement.value = `${loco.address}`;
-            this._functions = loco.functions || [];
-            this._cvs = loco.cvs || {};
-            if (loco.discrete) {
-                this._slowElement.value = `${loco.speeds[0]}`;
-                this._mediumElement.value = `${loco.speeds[1]}`;
-                this._fastElement.value = `${loco.speeds[2]}`;
-                this._discreteElement.checked = true;
-                this._discreteElement.onchange(null);
-            }
-            else {
-                this._maxSpeedEelement.value = `${loco.maxSpeed}`;
-            }
-            this._deleteButton.style.display = "";
-
-            if (previousPage instanceof FunctionSetupPage) {
-                if (this._haveFunctionsChanged(previousPage.functions)) {
-                    this._functions = previousPage.functions;
-                    this._save(false);
-                }
-            }
-            else if (previousPage instanceof CvEditorPage) {
-                if (this._haveCVsChanged(previousPage.cvs)) {
-                    this._cvs = previousPage.cvs;
-                    this._save(false);
-                }
-            }
-        }).catch((err) => {
+        this._loadDetails(previousPage).catch((err) => {
             console.error(err);
             prompt.error("Failed to load train details.");
         })
+    }
+
+    private async _loadDetails(previousPage: Page) {
+        if (!this._id) return;
+ 
+        const loco = await this._api.getLoco(this._id);
+
+        this._nameElement.value = loco.name;
+        this._addressElement.value = `${loco.address}`;
+        this._functions = loco.functions || [];
+        this._cvs = loco.cvs || {};
+        if (loco.discrete) {
+            this._slowElement.value = `${loco.speeds[0]}`;
+            this._mediumElement.value = `${loco.speeds[1]}`;
+            this._fastElement.value = `${loco.speeds[2]}`;
+            this._discreteElement.checked = true;
+            this._discreteElement.onchange(null);
+        }
+        else {
+            this._maxSpeedEelement.value = `${loco.maxSpeed}`;
+        }
+        this._deleteButton.style.display = "";
+
+        if (previousPage instanceof FunctionSetupPage) {
+            if (this._haveFunctionsChanged(previousPage.functions)) {
+                this._functions = previousPage.functions;
+                this._save(false);
+            }
+        }
+        else if (previousPage instanceof CvEditorPage) {
+            if (this._haveCVsChanged(previousPage.cvs)) {
+                this._cvs = previousPage.cvs;
+                this._save(false);
+            }
+        }
     }
 
     private _haveFunctionsChanged(newFunctions: FunctionConfig[]) {
@@ -161,7 +167,6 @@ export class TrainEditPage extends Page {
     }
 
     private _save(navBackOnSuccess: boolean) {
-        // TODO - Add protections against overlapped actions
         if (!this._validate()) return;
 
         prompt.confirm("Are you sure you want to save this train?").then((yes) => {

--- a/src/client/pages/trainEditor.ts
+++ b/src/client/pages/trainEditor.ts
@@ -138,9 +138,11 @@ export class TrainEditPage extends Page {
     private _updatePageParams() {
         const params: TrainEditParams = {}
 
+        // Determine if UI elements contain valid values before we update each paramter
         if (this._id) params.id = this._id;
         if (this._nameElement.value) params.name = this._nameElement.value;
         if (this._addressElement.value) params.address = parseInt(this._addressElement.value);
+        // Pack the speed values. This is different to the database format.
         if (this._discreteElement.checked) {
             const min = parseInt(this._slowElement.value);
             const med = parseInt(this._mediumElement.value);
@@ -216,6 +218,7 @@ export class TrainEditPage extends Page {
     }
 
     private _cancel() {
+        // Revert any potentially updated page parameters
         const params: TrainEditParams = {};
         if (this._id) params.id = this._id;
         nav.replaceParams(params);
@@ -241,7 +244,6 @@ export class TrainEditPage extends Page {
             else {
                 speed = parseInt(this._maxSpeedEelement.value);
             }
-
 
             let promise: Promise<any>;
             if (this._id) {

--- a/src/client/pages/trainEditor.ts
+++ b/src/client/pages/trainEditor.ts
@@ -19,7 +19,6 @@ export class TrainEditPage extends Page {
     content: HTMLElement;
 
     private _params: TrainEditParams;
-    private _id: number;
     private readonly _api: IApiClient;
     private _functions: FunctionConfig[] = [];
     private _cvs: CvMap = {};
@@ -36,7 +35,6 @@ export class TrainEditPage extends Page {
     constructor (params: TrainEditParams) {
         super();
         this._params = params || {};
-        this._id =  this._params.id ?? 0;
         this._api = client.api;
         this.content = this._buildUi();
     }
@@ -84,8 +82,8 @@ export class TrainEditPage extends Page {
         let address: number;
         let speeds: number[] = [];
 
-        if (this._id) {
-            const loco = await this._api.getLoco(this._id);
+        if (this._params.id) {
+            const loco = await this._api.getLoco(this._params.id);
 
             name = loco.name;
             address = loco.address;
@@ -136,10 +134,9 @@ export class TrainEditPage extends Page {
     }
 
     private _updatePageParams() {
-        const params: TrainEditParams = {}
+        const params: TrainEditParams = { id: this._params.id };
 
         // Determine if UI elements contain valid values before we update each paramter
-        if (this._id) params.id = this._id;
         if (this._nameElement.value) params.name = this._nameElement.value;
         if (this._addressElement.value) params.address = parseInt(this._addressElement.value);
         // Pack the speed values. This is different to the database format.
@@ -180,7 +177,7 @@ export class TrainEditPage extends Page {
         prompt.confirm("Are you sure you want to delete this train?").then(async (yes) => {
             if (!yes) return;
             try {
-                await this._api.deleteLoco(this._id);
+                await this._api.deleteLoco(this._params.id);
                 nav.replaceParams({});
                 nav.back();
             }
@@ -219,8 +216,7 @@ export class TrainEditPage extends Page {
 
     private _cancel() {
         // Revert any potentially updated page parameters
-        const params: TrainEditParams = {};
-        if (this._id) params.id = this._id;
+        const params: TrainEditParams = { id: this._params.id };
         nav.replaceParams(params);
         nav.back();
     }
@@ -246,12 +242,12 @@ export class TrainEditPage extends Page {
             }
 
             let promise: Promise<any>;
-            if (this._id) {
-                promise = this._api.updateLoco(this._id, name, address, speed, this._functions, this._cvs);
+            if (this._params.id) {
+                promise = this._api.updateLoco(this._params.id, name, address, speed, this._functions, this._cvs);
             }
             else {
                 promise = this._api.addLoco(name, address, speed, this._functions, this._cvs).then((loco) => {
-                    this._id = loco.id;
+                    this._params.id = loco.id;
                     this._updatePageParams();
                 });
             }


### PR DESCRIPTION
Train editor page parameters now support all the fields that can be edited. When navigating away from the train editor page, the page parameters are updated with the latest values from the UI elements.

Also fixed an issue with being prompted to save any time your returned from the CV editor due to always providing CV 7 and 8 values even when they hadn't been read.