### PR TITLE
Added WebSocket Command Station

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -577,9 +577,9 @@
       "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ=="
     },
     "@types/ws": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.1.tgz",
-      "integrity": "sha512-UEmRNbXFGvfs/sLncf01GuVv6U1mZP3Df0iXWx4kUlikJxbFyFADp95mDn1XDTE2mXpzzoHcKlfFcbytLq4vaA==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.5.tgz",
+      "integrity": "sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -2477,6 +2477,16 @@
       "integrity": "sha512-KEyUw8AwRET2iFjFsI1EJQrJ/fHeGiJtgpYgEWG3yDv4l/To/m3a2GaYfeGyB3lsWdvbesjF5XCMx+SVBgAAYw==",
       "requires": {
         "ws": "^5.2.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "extend": {
@@ -8021,12 +8031,9 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
     },
     "xml2js": {
       "version": "0.4.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itokawa",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/serialport": "^8.0.0",
     "@types/sinon": "^7.5.2",
     "@types/sqlite3": "^3.1.6",
+    "@types/ws": "^7.2.5",
     "@types/xml2js": "^0.4.5",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
@@ -48,6 +49,7 @@
     "qrcode": "^1.4.4",
     "serialport": "^8.0.7",
     "sqlite3": "^4.1.1",
+    "ws": "^7.3.0",
     "xml2js": "^0.4.23"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itokawa",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "DCC Train Control",
   "private": true,
   "scripts": {

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -172,7 +172,7 @@ export async function loco_function(context: CommandContext, args: string[]) {
 }
 loco_function.minArgs = 2;
 loco_function.maxArgs = 3;
-loco_function.help = "Set locomotive function.\n  Usage: loco_speed LOCO_ID SPEED [on|off]";
+loco_function.help = "Set locomotive function.\n  Usage: loco_function LOCO_ID FUNCTION [on|off]";
 
 // Loco Speed Control
 export async function loco_speed(context: CommandContext, args: string[]) {

--- a/src/devices/commandStations/commandStation.spec.ts
+++ b/src/devices/commandStations/commandStation.spec.ts
@@ -170,7 +170,7 @@ describe("Command Station Base", () => {
             await expect(cs.untilState(CommandStationState.IDLE)).to.be.eventually.rejectedWith("Command station is in ERROR state");
         })
 
-        it ("should reject with custom error istantly if already in error state but asked to await another state", async () => {
+        it ("should reject with custom error instantly if already in error state but asked to await another state", async () => {
             const cs = new TestCommmandStation();
             cs.setError(new Error("Custom Error"));
 

--- a/src/devices/commandStations/commandStation.spec.ts
+++ b/src/devices/commandStations/commandStation.spec.ts
@@ -54,6 +54,10 @@ describe("Command Station Base", () => {
         setIdle() {
             this._setIdle();
         }
+
+        setError(error: Error) {
+            this._setError(error);
+        }
     
         untilState(state: CommandStationState): Promise<void> {
             return this._untilState(state);
@@ -135,7 +139,7 @@ describe("Command Station Base", () => {
             expect(error.callCount).to.equal(0);
         })
 
-        it ("should reject waiting promise if error occurs while awaiting a state", async () => {
+        it ("should reject awaiting promise if error occurs while awaiting a state", async () => {
             const cs = new TestCommmandStation();
             const promise = cs.untilState(CommandStationState.IDLE);
             await nextTick();
@@ -145,11 +149,28 @@ describe("Command Station Base", () => {
             await expect(promise).to.be.eventually.rejectedWith("Command station is in ERROR state");
         })
 
+        it ("should reject with custom error awaiting promise if error occurs while awaiting a state", async () => {
+            const cs = new TestCommmandStation();
+            const promise = cs.untilState(CommandStationState.IDLE);
+            await nextTick();
+
+            cs.setError(new Error("Testing"))
+
+            await expect(promise).to.be.eventually.rejectedWith("Testing");
+        })
+
         it ("should reject istantly if already in error state bust asked to await another state", async () => {
             const cs = new TestCommmandStation();
             cs.setState(CommandStationState.ERROR);
 
             await expect(cs.untilState(CommandStationState.IDLE)).to.be.eventually.rejectedWith("Command station is in ERROR state");
+        })
+
+        it ("should reject with custom error istantly if already in error state bust asked to await another state", async () => {
+            const cs = new TestCommmandStation();
+            cs.setError(new Error("Custom Error"));
+
+            await expect(cs.untilState(CommandStationState.IDLE)).to.be.eventually.rejectedWith("Custom Error");
         })
 
         it ("should be safe to await the current state", async () => {

--- a/src/devices/commandStations/commandStation.ts
+++ b/src/devices/commandStations/commandStation.ts
@@ -121,7 +121,7 @@ export abstract class CommandStationBase extends EventEmitter implements IComman
             if (this.state === CommandStationState.ERROR)
                 reject(this._error ?? new CommandStationError("Command station is in ERROR state"));
 
-            const listener = async (newState: CommandStationState) => {
+            const listener = (newState: CommandStationState) => {
                 if (newState === state) {
                     this.off("state", listener);
                     resolve();

--- a/src/devices/commandStations/commandStation.ts
+++ b/src/devices/commandStations/commandStation.ts
@@ -116,17 +116,7 @@ export abstract class CommandStationBase extends EventEmitter implements IComman
     // This is to avoid batch commits waiting on command stations that have failed and may never
     // recover.
     protected _untilState(state: CommandStationState): Promise<void> {
-        if (this.state === state) return Promise.resolve();
         return new Promise((resolve, reject) => {
-            if (this.state === CommandStationState.ERROR) {
-                reject(this._error ?? new CommandStationError("Command station is in ERROR state"));
-                return; 
-            }
-            else if (this.state === CommandStationState.NOT_CONNECTED && state !== CommandStationState.NOT_CONNECTED) {
-                reject(new CommandStationError("Connection closed"));
-                return;
-            }
-
             const listener = (newState: CommandStationState) => {
                 if (newState === state) {
                     this.off("state", listener);
@@ -142,6 +132,7 @@ export abstract class CommandStationBase extends EventEmitter implements IComman
                 }
             };
             this.on("state", listener);
+            listener(this.state);
         });
     }
 

--- a/src/devices/commandStations/commandStationDirectory.ts
+++ b/src/devices/commandStations/commandStationDirectory.ts
@@ -2,6 +2,7 @@ import { DeviceEnumerator } from "../deviceEnumerator";
 import { ELinkCommandStation } from "./elink";
 import { NullCommandStation } from "./null";
 import { RawCommandStation } from "./raw";
+import { WebSocketCommandStation } from "./websocket";
 
 export function registerCommandStations() {
 
@@ -10,5 +11,6 @@ export function registerCommandStations() {
 
     DeviceEnumerator.registerDevice(NullCommandStation, "__TEST__");
     DeviceEnumerator.registerDevice(RawCommandStation);
+    DeviceEnumerator.registerDevice(WebSocketCommandStation);
 }
 

--- a/src/devices/commandStations/nmraUtils.spec.ts
+++ b/src/devices/commandStations/nmraUtils.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import "mocha";
 import "./nmraUtils";
-import { encodeLongAddress, decodeLongAddress, ensureWithinRange, ensureCvNumber, ensureByte, ensureAddress } from "./nmraUtils";
+import { encodeLongAddress, decodeLongAddress, ensureWithinRange, ensureCvNumber, ensureByte, ensureAddress, ensureSpeed, ensureFunction } from "./nmraUtils";
 
 describe("NMRA Utilities", () => {
     describe("encodeLongAddress", () => {
@@ -139,7 +139,7 @@ describe("NMRA Utilities", () => {
             expect(() => ensureWithinRange(1, 2, 10, "Test Value")).to.throw("Test Value outside of valid range");
         })
 
-        it("should reject value below lower bound", () => {
+        it("should reject value above upper bound", () => {
             expect(() => ensureWithinRange(11, 2, 10, "Test Value")).to.throw("Test Value outside of valid range");
         })
     })
@@ -161,7 +161,7 @@ describe("NMRA Utilities", () => {
             expect(() => ensureAddress(0)).to.throw("Address 0 outside of valid range");
         })
 
-        it("should reject value below lower bound", () => {
+        it("should reject value above upper bound", () => {
             expect(() => ensureAddress(10000)).to.throw("Address 10000 outside of valid range");
         })
     })
@@ -183,7 +183,7 @@ describe("NMRA Utilities", () => {
             expect(() => ensureCvNumber(0)).to.throw("CV 0 outside of valid range");
         })
 
-        it("should reject value below lower bound", () => {
+        it("should reject value above upper bound", () => {
             expect(() => ensureCvNumber(256)).to.throw("CV 256 outside of valid range");
         })
     })
@@ -205,8 +205,52 @@ describe("NMRA Utilities", () => {
             expect(() => ensureByte(-1)).to.throw("Byte(-1) outside of valid range");
         })
 
-        it("should reject value below lower bound", () => {
+        it("should reject value above upper bound", () => {
             expect(() => ensureByte(256)).to.throw("Byte(256) outside of valid range");
+        })
+    })
+
+    describe("ensureSpeed", () => {
+        it("should accept value at lower bound", () => {
+            ensureSpeed(0);
+        })
+
+        it("should accept value at upper bound", () => {
+            ensureSpeed(127);
+        })
+
+        it("should accept value within range", () => {
+            ensureSpeed(64);
+        })
+
+        it("should reject value below lower bound", () => {
+            expect(() => ensureSpeed(-1)).to.throw("Speed -1 outside of valid range");
+        })
+
+        it("should reject value above upper bound", () => {
+            expect(() => ensureSpeed(128)).to.throw("Speed 128 outside of valid range");
+        })
+    })
+
+    describe("ensureFunction", () => {
+        it("should accept value at lower bound", () => {
+            ensureFunction(0);
+        })
+
+        it("should accept value at upper bound", () => {
+            ensureFunction(28);
+        })
+
+        it("should accept value within range", () => {
+            ensureFunction(14);
+        })
+
+        it("should reject value below lower bound", () => {
+            expect(() => ensureFunction(-1)).to.throw("Function -1 outside of valid range");
+        })
+
+        it("should reject value above upper bound", () => {
+            expect(() => ensureFunction(29)).to.throw("Function 29 outside of valid range");
         })
     })
 });

--- a/src/devices/commandStations/nmraUtils.ts
+++ b/src/devices/commandStations/nmraUtils.ts
@@ -38,3 +38,11 @@ export function ensureCvNumber(cv: number) {
 export function ensureByte(value: number) {
     ensureWithinRange(value, 0, 255, `Byte(${value})`);
 }
+
+export function ensureSpeed(speed: number) {
+    ensureWithinRange(speed, 0, 127, `Speed ${speed}`);
+}
+
+export function ensureFunction(func: number) {
+    ensureWithinRange(func, 0, 28, `Function ${func}`);
+}

--- a/src/devices/commandStations/raw.spec.ts
+++ b/src/devices/commandStations/raw.spec.ts
@@ -3,7 +3,6 @@ use(require("chai-as-promised"));
 import "mocha";
 import { stub, SinonStub } from "sinon"
 import { createSinonStubInstance, StubbedClass } from "../../utils/testUtils"
-import { nextTick } from "../../utils/promiseUtils"
 import { AsyncSerialPort } from "../asyncSerialPort"
 import { RawCommandStation } from "./raw"
 import { CommandStationState } from "./commandStation";

--- a/src/devices/commandStations/websocket.spec.ts
+++ b/src/devices/commandStations/websocket.spec.ts
@@ -348,6 +348,38 @@ describe("WebSocket Command Station", () => {
         })
     })
 
+    describe("socket error handling", () => {
+        it("should transition to error state on socket error", async () => {
+            const eventListener = stub();
+            const cs = await open();
+            cs.on("state", eventListener);
+
+            webSocketMock.emit("error", new Error("Socket Error"));
+
+            expect(cs.state).to.equal(CommandStationState.ERROR);
+            expect(eventListener.callCount).to.equal(1);
+            expect(eventListener.lastCall.args).to.eql([
+                CommandStationState.ERROR,
+                CommandStationState.IDLE
+            ]);
+        })
+
+        it("should transition to error state if the socket closes unexpectedly", async () => {
+            const eventListener = stub();
+            const cs = await open();
+            cs.on("state", eventListener);
+
+            webSocketMock.emit("close", -1, "closed");
+
+            expect(cs.state).to.equal(CommandStationState.ERROR);
+            expect(eventListener.callCount).to.equal(1);
+            expect(eventListener.lastCall.args).to.eql([
+                CommandStationState.ERROR,
+                CommandStationState.IDLE
+            ]);
+        })
+    })
+
     describe("WebSocketCommandBatch", () => {
         describe("setLocomotiveSpeed", () => {
             it("should generate a valid request", async () => {

--- a/src/devices/commandStations/websocket.spec.ts
+++ b/src/devices/commandStations/websocket.spec.ts
@@ -1,6 +1,9 @@
 import { expect } from "chai";
 import "mocha";
 import { stub, SinonStub, restore } from "sinon"
+import { nextTick } from "../../utils/promiseUtils"
+import * as messages from "../../common/messages";
+import { timestamp } from "../../common/time";
 import { WebSocketCommandStation } from "./websocket"
 import * as WebSocket from "ws";
 import { CommandStationState } from "./commandStation";
@@ -9,6 +12,8 @@ const CONNECTION_STRING = "url=wss://foo/bar";
 
 class WebSocketMock {
     callbacks:{[key: string]: (...args: any[])  => void } = {}
+    sentData: any[] = [];
+    lastTag: string = null;
     close = stub();
 
     on(event: string, func: (...args: any[])  => void) {
@@ -17,6 +22,51 @@ class WebSocketMock {
 
     emit(event: string, ...args: any[]) {
         this.callbacks[event](...args);
+    }
+
+    send(data: string) {
+        const message = JSON.parse(data) as messages.TransportMessage;
+        this.lastTag = message.tag;
+        this.sentData.push(message);
+    }
+
+    postResponse<T>(tag: string, data: T) {
+        const message: messages.TransportMessage = {
+            type: messages.RequestType.CommandResponse,
+            tag: tag,
+            requestTime: timestamp(),
+            data: {
+                lastMessage: false,
+                data: data
+            }
+        };
+        this.emit("message", JSON.stringify(message));
+    }
+
+    postOk(tag: string) {
+        const message: messages.TransportMessage = {
+            type: messages.RequestType.CommandResponse,
+            tag: tag,
+            requestTime: timestamp(),
+            data: {
+                lastMessage: true,
+                data: "OK"
+            }
+        };
+        this.emit("message", JSON.stringify(message));
+    }
+
+    postError(tag: string, error: string) {
+        const message: messages.TransportMessage = {
+            type: messages.RequestType.CommandResponse,
+            tag: tag,
+            requestTime: timestamp(),
+            data: {
+                lastMessage: true,
+                error: error
+            }
+        };
+        this.emit("message", JSON.stringify(message));
     }
 }
 
@@ -67,6 +117,11 @@ describe("WebSocket Command Station", () => {
 
             await expect(promise).to.be.rejectedWith("WebSocket closed unexpectedly. Reason: Test Close");
         })
+
+        it("should raise an exception if the service is not listening", async () => {
+            restore();
+            await expect(WebSocketCommandStation.open("url=ws://127.0.0.1:0/")).to.be.rejectedWith(/EADDRNOTAVAIL/);
+        })
     })
 
     describe("close", () => {
@@ -79,6 +134,104 @@ describe("WebSocket Command Station", () => {
 
             expect(webSocketMock.close.callCount).to.equal(1);
             expect(webSocketMock.close.lastCall.args).to.eql([]);
+        })
+    })
+
+    describe("readLocoCv", () => {
+        it("issues request for CV and returns value", async () => {
+            const cv = 123;
+            const cvValue = 17;
+
+            const cs = await open();
+            const promise = cs.readLocoCv(cv);
+            await nextTick();
+
+            expect(cs.state).to.equal(CommandStationState.BUSY);
+            expect(webSocketMock.sentData).to.have.length(1);
+            const request = webSocketMock.sentData[0] as messages.TransportMessage;
+            expect(request.type).to.equal(messages.RequestType.LocoCvRead);
+            expect(request.requestTime).to.be.a("string").and.not.be.empty;
+            expect(request.tag).to.be.a("string").and.not.be.empty;
+            expect(request.data).to.eql({
+                cvs: [cv]
+            });
+
+            webSocketMock.postResponse<messages.CvValuePair>(request.tag, {
+                cv: cv,
+                value: cvValue
+            });
+            webSocketMock.postOk(request.tag);
+
+            expect(await promise).to.equal(cvValue);
+            expect(cs.state).to.equal(CommandStationState.IDLE);
+        })
+
+        it("raises exception for incorrect CV", async () => {
+            const cs = await open();
+            const promise = cs.readLocoCv(12);
+            await nextTick();
+            const tag = webSocketMock.lastTag;
+
+            webSocketMock.postResponse<messages.CvValuePair>(tag, {
+                cv: 2,
+                value: 1
+            });
+            webSocketMock.postOk(tag);
+
+            await expect(promise).to.be.rejectedWith("No CV data returned");
+            expect(cs.state).to.equal(CommandStationState.IDLE);
+        })
+
+        it("raises exception if no CV data received", async () => {
+            const cs = await open();
+            const promise = cs.readLocoCv(12);
+            await nextTick();
+            webSocketMock.postOk(webSocketMock.lastTag);
+
+            await expect(promise).to.be.rejectedWith("No CV data returned");
+            expect(cs.state).to.equal(CommandStationState.IDLE);
+        })
+
+        it("raises exception if error returned by service", async () => {
+            const cs = await open();
+            const promise = cs.readLocoCv(12);
+            await nextTick();
+            webSocketMock.postError(webSocketMock.lastTag, "Test Error");
+
+            await expect(promise).to.be.rejectedWith("Test Error");
+            expect(cs.state).to.equal(CommandStationState.IDLE);
+        })
+
+        it("raises exception if there is an underlying socket exception", async () => {
+            const cs = await open();
+            const promise = cs.readLocoCv(12);
+            await nextTick();
+            webSocketMock.emit("error", new Error("Socket Error"));
+
+            await expect(promise).to.be.rejectedWith("Socket Error");
+            expect(cs.state).to.equal(CommandStationState.ERROR);
+        })
+    })
+
+    describe("Received message handling", () => {
+        it("safely ignores irrelevate messages", async () => {
+            const cs = await open();
+
+            webSocketMock.postResponse<string>("foo", "bar");
+            await nextTick();
+            await nextTick();
+
+            expect(cs.state).to.equal(CommandStationState.IDLE);
+        })
+
+        it("to ignore malformed messages", async () => {
+            const cs = await open();
+
+            webSocketMock.emit("message", "dasgsdgs");
+            await nextTick();
+            await nextTick();
+
+            expect(cs.state).to.equal(CommandStationState.IDLE);
         })
     })
 })

--- a/src/devices/commandStations/websocket.spec.ts
+++ b/src/devices/commandStations/websocket.spec.ts
@@ -4,15 +4,15 @@ import { stub, SinonStub, restore } from "sinon"
 import { nextTick } from "../../utils/promiseUtils"
 import * as messages from "../../common/messages";
 import { timestamp } from "../../common/time";
-import { WebSocketCommandStation } from "./websocket"
+import { WebSocketCommandBatch, WebSocketCommandStation } from "./websocket"
 import * as WebSocket from "ws";
-import { CommandStationState } from "./commandStation";
+import { CommandStationState, FunctionAction } from "./commandStation";
 
-const CONNECTION_STRING = "url=wss://foo/bar";
+const CONNECTION_STRING = "url=wss://localhost/control/v1";
 
 class WebSocketMock {
     callbacks:{[key: string]: (...args: any[])  => void } = {}
-    sentData: any[] = [];
+    sentData: messages.TransportMessage[] = [];
     lastTag: string = null;
     close = stub();
 
@@ -43,7 +43,8 @@ class WebSocketMock {
         this.emit("message", JSON.stringify(message));
     }
 
-    postOk(tag: string) {
+    postOk(tag?: string) {
+        tag = tag || this.lastTag;
         const message: messages.TransportMessage = {
             type: messages.RequestType.CommandResponse,
             tag: tag,
@@ -93,7 +94,7 @@ describe("WebSocket Command Station", () => {
         it("should establish a connection", async () => {
             const cs = await open();
             expect(createSocketStub.callCount).to.equal(1);
-            expect(createSocketStub.lastCall.args).to.eql(["wss://foo/bar"]);
+            expect(createSocketStub.lastCall.args).to.eql(["wss://localhost/control/v1"]);
             expect(cs.state).to.equal(CommandStationState.IDLE);
         })
 
@@ -148,7 +149,7 @@ describe("WebSocket Command Station", () => {
 
             expect(cs.state).to.equal(CommandStationState.BUSY);
             expect(webSocketMock.sentData).to.have.length(1);
-            const request = webSocketMock.sentData[0] as messages.TransportMessage;
+            const request = webSocketMock.sentData[0];
             expect(request.type).to.equal(messages.RequestType.LocoCvRead);
             expect(request.requestTime).to.be.a("string").and.not.be.empty;
             expect(request.tag).to.be.a("string").and.not.be.empty;
@@ -311,7 +312,22 @@ describe("WebSocket Command Station", () => {
     })
 
     describe("Received message handling", () => {
-        it("safely ignores irrelevate messages", async () => {
+        it("should ignore non-response messages", async () => {
+            const cs = await open();
+
+            webSocketMock.emit("message", JSON.stringify({
+                type: messages.RequestType.LocoSpeed,
+                tag: "foo",
+                requestTime: "bar",
+                data: "baz"
+            } as messages.TransportMessage));
+            await nextTick();
+            await nextTick();
+
+            expect(cs.state).to.equal(CommandStationState.IDLE);
+        })
+
+        it("should ignore irrelevate messages", async () => {
             const cs = await open();
 
             webSocketMock.postResponse<string>("foo", "bar");
@@ -321,7 +337,7 @@ describe("WebSocket Command Station", () => {
             expect(cs.state).to.equal(CommandStationState.IDLE);
         })
 
-        it("to ignore malformed messages", async () => {
+        it("should ignore malformed messages", async () => {
             const cs = await open();
 
             webSocketMock.emit("message", "dasgsdgs");
@@ -330,5 +346,206 @@ describe("WebSocket Command Station", () => {
 
             expect(cs.state).to.equal(CommandStationState.IDLE);
         })
+    })
+
+    describe("WebSocketCommandBatch", () => {
+        describe("setLocomotiveSpeed", () => {
+            it("should generate a valid request", async () => {
+                const cs = await open();
+                const batch = await cs.beginCommandBatch();
+                batch.setLocomotiveSpeed(3, 64);
+
+                const promise = batch.commit();
+                await nextTick();
+
+                expect(cs.state).to.equal(CommandStationState.BUSY);
+                expect(webSocketMock.sentData).to.have.length(1);
+                const request = webSocketMock.sentData[0];
+                expect(request.type).to.equal(messages.RequestType.LocoSpeed);
+                expect(request.tag).to.be.a("string").and.not.empty;
+                expect(request.requestTime).to.be.a("string").and.not.empty;
+                expect(request.data).to.eql({
+                    locoId: 3,
+                    speed: 64
+                } as messages.LocoSpeedRequest);
+
+                webSocketMock.postOk();
+                await promise;
+                expect(cs.state).to.equal(CommandStationState.IDLE);
+            })
+
+            it("should generate a valid batch", async () => {
+                const cs = await open();
+                const batch = await cs.beginCommandBatch();
+                batch.setLocomotiveSpeed(12, 32, true);
+                batch.setLocomotiveSpeed(9999, 127, false);
+
+                const promise = batch.commit();
+                await nextTick();
+
+                expect(cs.state).to.equal(CommandStationState.BUSY);
+                expect(webSocketMock.sentData).to.have.length(1);
+                let request = webSocketMock.sentData[0];
+                expect(request.type).to.equal(messages.RequestType.LocoSpeed);
+                expect(request.tag).to.be.a("string").and.not.empty;
+                expect(request.requestTime).to.be.a("string").and.not.empty;
+                expect(request.data).to.eql({
+                    locoId: 12,
+                    speed: 32,
+                    reverse: true
+                } as messages.LocoSpeedRequest);
+
+                webSocketMock.postOk();
+                await nextTick();
+
+                expect(webSocketMock.sentData).to.have.length(2);
+                request = webSocketMock.sentData[1];
+                expect(request.type).to.equal(messages.RequestType.LocoSpeed);
+                expect(request.tag).to.be.a("string").and.not.empty;
+                expect(request.requestTime).to.be.a("string").and.not.empty;
+                expect(request.data).to.eql({
+                    locoId: 9999,
+                    speed: 127,
+                    reverse: false
+                } as messages.LocoSpeedRequest);
+
+                webSocketMock.postOk();
+                await promise;
+                expect(cs.state).to.equal(CommandStationState.IDLE);
+            })
+
+            it("should raise excption if batch is committed", async () => {
+                const batch = new WebSocketCommandBatch(() => Promise.resolve());
+                batch.setLocomotiveSpeed(3, 64);
+                await batch.commit();
+
+                expect(() => batch.setLocomotiveSpeed(1, 2)).to.throw("Command batch already committed");
+            })
+
+            it("should raise exception if loco id is invalid", () => {
+                const batch = new WebSocketCommandBatch(() => Promise.resolve());
+
+                expect(() => batch.setLocomotiveSpeed(0, 64)).to.throw("Address 0 outside of valid range");
+                expect(() => batch.setLocomotiveSpeed(10000, 64)).to.throw("Address 10000 outside of valid range");
+            })
+
+            it("should raise exception if speed is invalid", () => {
+                const batch = new WebSocketCommandBatch(() => Promise.resolve());
+
+                expect(() => batch.setLocomotiveSpeed(3, -1)).to.throw("Speed -1 outside of valid range");
+                expect(() => batch.setLocomotiveSpeed(3, 128)).to.throw("Speed 128 outside of valid range");
+            })
+        })
+
+        describe("setLocomotiveFunction", () => {
+            it("should generate a valid request", async () => {
+                const cs = await open();
+                const batch = await cs.beginCommandBatch();
+                batch.setLocomotiveFunction(3, 1, FunctionAction.TRIGGER);
+
+                const promise = batch.commit();
+                await nextTick();
+
+                expect(cs.state).to.equal(CommandStationState.BUSY);
+                expect(webSocketMock.sentData).to.have.length(1);
+                const request = webSocketMock.sentData[0];
+                expect(request.type).to.equal(messages.RequestType.LocoFunction);
+                expect(request.tag).to.be.a("string").and.not.empty;
+                expect(request.requestTime).to.be.a("string").and.not.empty;
+                expect(request.data).to.eql({
+                    locoId: 3,
+                    function: 1,
+                    action: messages.FunctionAction.Trigger
+                } as messages.LocoFunctionRequest);
+
+                webSocketMock.postOk();
+                await promise;
+                expect(cs.state).to.equal(CommandStationState.IDLE);
+            })
+
+            it("should generate a valid batch", async () => {
+                const cs = await open();
+                const batch = await cs.beginCommandBatch();
+                batch.setLocomotiveFunction(12, 12, FunctionAction.LATCH_ON);
+                batch.setLocomotiveFunction(9999, 28, FunctionAction.LATCH_OFF);
+
+                const promise = batch.commit();
+                await nextTick();
+
+                expect(cs.state).to.equal(CommandStationState.BUSY);
+                expect(webSocketMock.sentData).to.have.length(1);
+                let request = webSocketMock.sentData[0];
+                expect(request.type).to.equal(messages.RequestType.LocoFunction);
+                expect(request.tag).to.be.a("string").and.not.empty;
+                expect(request.requestTime).to.be.a("string").and.not.empty;
+                expect(request.data).to.eql({
+                    locoId: 12,
+                    function: 12,
+                    action: messages.FunctionAction.LatchOn
+                } as messages.LocoFunctionRequest);
+
+                webSocketMock.postOk();
+                await nextTick();
+
+                expect(webSocketMock.sentData).to.have.length(2);
+                request = webSocketMock.sentData[1];
+                expect(request.type).to.equal(messages.RequestType.LocoFunction);
+                expect(request.tag).to.be.a("string").and.not.empty;
+                expect(request.requestTime).to.be.a("string").and.not.empty;
+                expect(request.data).to.eql({
+                    locoId: 9999,
+                    function: 28,
+                    action: messages.FunctionAction.LatchOff
+                } as messages.LocoFunctionRequest);
+
+                webSocketMock.postOk();
+                await promise;
+                expect(cs.state).to.equal(CommandStationState.IDLE);
+            })
+
+            it("should raise excption if batch is committed", async () => {
+                const batch = new WebSocketCommandBatch(() => Promise.resolve());
+                batch.setLocomotiveFunction(3, 1, FunctionAction.TRIGGER);
+                await batch.commit();
+
+                expect(() => batch.setLocomotiveFunction(3, 1, FunctionAction.TRIGGER)).to.throw("Command batch already committed");
+            })
+
+            it("should raise exception if loco id is invalid", () => {
+                const batch = new WebSocketCommandBatch(() => Promise.resolve());
+
+                expect(() => batch.setLocomotiveFunction(0, 0, FunctionAction.LATCH_ON)).to.throw("Address 0 outside of valid range");
+                expect(() => batch.setLocomotiveFunction(10000, 0, FunctionAction.LATCH_OFF)).to.throw("Address 10000 outside of valid range");
+            })
+
+            it("should raise exception if function is invalid", () => {
+                const batch = new WebSocketCommandBatch(() => Promise.resolve());
+
+                expect(() => batch.setLocomotiveFunction(3, -1, FunctionAction.TRIGGER)).to.throw("Function -1 outside of valid range");
+                expect(() => batch.setLocomotiveFunction(3, 29, FunctionAction.TRIGGER)).to.throw("Function 29 outside of valid range");
+            })
+
+            it("should raise exception if action is invalid", () => {
+                const batch = new WebSocketCommandBatch(() => Promise.resolve());
+
+                expect(() => batch.setLocomotiveFunction(3, 0, -1)).to.throw("Invalid action -1");
+                expect(() => batch.setLocomotiveFunction(3, 0, 4)).to.throw("Invalid action 4");
+            })
+        })
+
+        describe("writeRaw", () => {
+            it("should raise an exception", () => {
+                const batch = new WebSocketCommandBatch(() => Promise.resolve());
+                expect(() => batch.writeRaw([0, 0, 0, 0])).to.throw("Raw writes are not unsupported");
+            })
+        })
+
+        describe("commit", () => {
+            it("should raise an exception if batch is already committed", async () => {
+                const batch = new WebSocketCommandBatch(() => Promise.resolve());
+                await batch.commit();
+                await expect(batch.commit()).to.be.eventually.rejectedWith("Command batch already committed");
+            })
+        });
     })
 })

--- a/src/devices/commandStations/websocket.spec.ts
+++ b/src/devices/commandStations/websocket.spec.ts
@@ -9,6 +9,7 @@ const CONNECTION_STRING = "url=wss://foo/bar";
 
 class WebSocketMock {
     callbacks:{[key: string]: (...args: any[])  => void } = {}
+    close = stub();
 
     on(event: string, func: (...args: any[])  => void) {
         this.callbacks[event] = func
@@ -65,6 +66,19 @@ describe("WebSocket Command Station", () => {
             webSocketMock.emit("close", -1, "Test Close");
 
             await expect(promise).to.be.rejectedWith("WebSocket closed unexpectedly. Reason: Test Close");
+        })
+    })
+
+    describe("close", () => {
+        it("waits until close event fired", async () => {
+            const cs = await open();
+
+            const promise = cs.close();
+            webSocketMock.emit("close", 0, "Closed");
+            await promise;
+
+            expect(webSocketMock.close.callCount).to.equal(1);
+            expect(webSocketMock.close.lastCall.args).to.eql([]);
         })
     })
 })

--- a/src/devices/commandStations/websocket.spec.ts
+++ b/src/devices/commandStations/websocket.spec.ts
@@ -32,16 +32,39 @@ describe("WebSocket Command Station", () => {
         restore();
     })
 
+    function open(connectionString = CONNECTION_STRING) {
+        const promise = WebSocketCommandStation.open(CONNECTION_STRING);
+        webSocketMock.emit("open");
+        return promise;
+    }
+
     describe("open", () => {
         it("should establish a connection", async () => {
-            const promise = WebSocketCommandStation.open(CONNECTION_STRING);
+            const cs = await open();
             expect(createSocketStub.callCount).to.equal(1);
             expect(createSocketStub.lastCall.args).to.eql(["wss://foo/bar"]);
-
-            webSocketMock.emit("open");
-
-            const cs = await promise;
             expect(cs.state).to.equal(CommandStationState.IDLE);
+        })
+
+        it("should be rejected if no URL provided", async () => {
+            await expect(WebSocketCommandStation.open("foo=bar")).to.be.rejectedWith('"url" not specified in connection string');
+            expect(createSocketStub.callCount).to.equal(0);
+        })
+
+        it("should be rejected if there is an error connecting", async () => {
+            const promise = WebSocketCommandStation.open(CONNECTION_STRING);
+
+            webSocketMock.emit("error", new Error("Test Error"));
+
+            await expect(promise).to.be.rejectedWith("Test Error");
+        })
+
+        it("should be rejected if the socket is closed unexpectedly", async () => {
+            const promise = WebSocketCommandStation.open(CONNECTION_STRING);
+
+            webSocketMock.emit("close", -1, "Test Close");
+
+            await expect(promise).to.be.rejectedWith("WebSocket closed unexpectedly. Reason: Test Close");
         })
     })
 })

--- a/src/devices/commandStations/websocket.spec.ts
+++ b/src/devices/commandStations/websocket.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from "chai";
+import "mocha";
+import { stub, SinonStub, restore } from "sinon"
+import { WebSocketCommandStation } from "./websocket"
+import * as WebSocket from "ws";
+import { CommandStationState } from "./commandStation";
+
+const CONNECTION_STRING = "url=wss://foo/bar";
+
+class WebSocketMock {
+    callbacks:{[key: string]: (...args: any[])  => void } = {}
+
+    on(event: string, func: (...args: any[])  => void) {
+        this.callbacks[event] = func
+    }
+
+    emit(event: string, ...args: any[]) {
+        this.callbacks[event](...args);
+    }
+}
+
+describe("WebSocket Command Station", () => {
+    let createSocketStub: SinonStub = null;
+    let webSocketMock: WebSocketMock = null;
+
+    beforeEach(() => {
+        webSocketMock = new WebSocketMock();
+        createSocketStub = stub(WebSocketCommandStation, "createSocket").returns(webSocketMock as unknown as WebSocket);
+    })
+
+    afterEach(() => {
+        restore();
+    })
+
+    describe("open", () => {
+        it("should establish a connection", async () => {
+            const promise = WebSocketCommandStation.open(CONNECTION_STRING);
+            expect(createSocketStub.callCount).to.equal(1);
+            expect(createSocketStub.lastCall.args).to.eql(["wss://foo/bar"]);
+
+            webSocketMock.emit("open");
+
+            const cs = await promise;
+            expect(cs.state).to.equal(CommandStationState.IDLE);
+        })
+    })
+})

--- a/src/devices/commandStations/websocket.ts
+++ b/src/devices/commandStations/websocket.ts
@@ -92,6 +92,14 @@ export class WebSocketCommandStation extends CommandStationBase {
         }
     }
 
+    private _onError(err: Error) {
+        this._setError(err);
+        if (this._requestReject) {
+            this._requestReject(err);
+            this._clearRequest();
+        }
+    }
+
     private _onMessage(message: messages.TransportMessage) {
         if (message.type !== messages.RequestType.CommandResponse) return;
         if (message.tag !== this._requestTag) return;
@@ -139,14 +147,6 @@ export class WebSocketCommandStation extends CommandStationBase {
             this._requestReject = reject;
             this._ws.send(JSON.stringify(message));
         });
-    }
-
-    private _onError(err: Error) {
-        this._setError(err);
-        if (this._requestReject) {
-            this._requestReject(err);
-            this._clearRequest();
-        }
     }
 
     close(): Promise<void> {

--- a/src/devices/commandStations/websocket.ts
+++ b/src/devices/commandStations/websocket.ts
@@ -150,8 +150,11 @@ export class WebSocketCommandStation extends CommandStationBase {
     }
 
     close(): Promise<void> {
-        this._setState(CommandStationState.SHUTTING_DOWN);
-        this._ws.close();
+        if (this.state === CommandStationState.NOT_CONNECTED) return Promise.resolve();
+        if (this.state !== CommandStationState.SHUTTING_DOWN) {
+            this._setState(CommandStationState.SHUTTING_DOWN);
+            this._ws.close();
+        }
         return this._untilState(CommandStationState.NOT_CONNECTED);
     }
 

--- a/src/devices/commandStations/websocket.ts
+++ b/src/devices/commandStations/websocket.ts
@@ -1,0 +1,102 @@
+import { Logger } from "../../utils/logger";
+import { CommandStationBase, ICommandBatch, CommandStationState, ICommandStation, FunctionAction, CommandStationError } from "./commandStation";
+import { parseConnectionString } from "../../utils/parsers";
+import { ensureCvNumber, ensureByte } from "./nmraUtils";
+import * as WebSocket from "ws";
+//import WebSocket = require("ws");
+
+const log = new Logger("WebSocketCommandStation");
+
+export class WebSocketCommandStation extends CommandStationBase {
+    static readonly deviceId = "WebSocketCommandStation";
+    readonly version: string = "1.0.0"
+    readonly deviceId: string = WebSocketCommandStation.deviceId;
+
+    readonly url: string = null;
+    private _ws: WebSocket = null;
+
+    static async open(connectionString?: string): Promise<ICommandStation> {
+        let cs = new WebSocketCommandStation(connectionString);
+        await cs.connect();
+        return cs
+    }
+
+    constructor(connectionString: string) {
+        super(log);
+        const config = parseConnectionString(connectionString);
+        this.url = config.url;
+        this._setState(CommandStationState.INITIALISING);
+
+        this._ws = new WebSocket(this.url);
+        this._ws.on("open", () => {
+            this._onOpen();
+        });
+        this._ws.on("close", (_, reason) => {
+            this._onClose(reason);
+        });
+        this._ws.on("error", (err) => {
+            this._onError(err);
+        });
+    }
+
+    async connect() {
+        await this._untilIdle();
+    }
+
+    private _onOpen() {
+        if (this.state !== CommandStationState.INITIALISING) {
+            this._onError(new CommandStationError("WebSocket received unexpected open event"));
+        }
+        else {
+            this._setIdle();
+        }
+    }
+
+    private _onClose(reason: string) {
+
+    }
+
+    private _onError(err: Error) {
+
+    }
+
+    close(): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+
+    beginCommandBatch(): Promise<ICommandBatch> {
+        throw new Error("Method not implemented.");
+    }
+
+    readLocoCv(cv: number): Promise<number> {
+        return Promise.reject(new Error("CV reading is not supported"));
+    }
+
+    writeLocoCv(cv: number, value: number): Promise<void> {
+        return Promise.reject(new Error("CV writing is not supported"));
+    }
+}
+
+export class WebSocketCommandBatch implements ICommandBatch {
+    constructor(private readonly _commit: ()=>Promise<void>) {
+
+    }
+
+    async commit()
+    {
+        await this._commit();
+        log.verbose("Committed command batch");
+    }
+    
+    setLocomotiveSpeed(locomotiveId: number, speed: number, reverse?: boolean): void {
+        log.verbose(() => `setLocomotiveSpeed - locoId=${locomotiveId}, speed=${speed}, reverse=${!!reverse}`);
+    }
+
+    setLocomotiveFunction(locomotiveId: number, func: number, action: FunctionAction): void {
+        log.verbose(() => `setLocomotiveFunction - locoId=${locomotiveId}, function=${func}, action=${FunctionAction[action]}`);
+    }
+
+    writeRaw(data: Buffer | number[]): void {
+        throw new CommandStationError("Raw writes are not unsupported");
+    }
+}

--- a/src/devices/commandStations/websocket.ts
+++ b/src/devices/commandStations/websocket.ts
@@ -3,7 +3,6 @@ import { CommandStationBase, ICommandBatch, CommandStationState, ICommandStation
 import { parseConnectionString } from "../../utils/parsers";
 import { ensureCvNumber, ensureByte } from "./nmraUtils";
 import * as WebSocket from "ws";
-//import WebSocket = require("ws");
 
 const log = new Logger("WebSocketCommandStation");
 
@@ -21,13 +20,17 @@ export class WebSocketCommandStation extends CommandStationBase {
         return cs
     }
 
+    static createSocket(url: string) {
+        return new WebSocket(url);
+    }
+
     constructor(connectionString: string) {
         super(log);
         const config = parseConnectionString(connectionString);
         this.url = config.url;
         this._setState(CommandStationState.INITIALISING);
 
-        this._ws = new WebSocket(this.url);
+        this._ws = WebSocketCommandStation.createSocket(this.url);
         this._ws.on("open", () => {
             this._onOpen();
         });

--- a/src/devices/commandStations/websocket.ts
+++ b/src/devices/commandStations/websocket.ts
@@ -27,6 +27,7 @@ export class WebSocketCommandStation extends CommandStationBase {
     constructor(connectionString: string) {
         super(log);
         const config = parseConnectionString(connectionString);
+        if (!config.url) throw new CommandStationError('"url" not specified in connection string');
         this.url = config.url;
         this._setState(CommandStationState.INITIALISING);
 
@@ -56,11 +57,16 @@ export class WebSocketCommandStation extends CommandStationBase {
     }
 
     private _onClose(reason: string) {
-
+        if (this.state != CommandStationState.SHUTTING_DOWN) {
+            this._setError(new CommandStationError(`WebSocket closed unexpectedly. Reason: ${reason}`));
+        }
+        else {
+            this._setState(CommandStationState.NOT_CONNECTED);
+        }
     }
 
     private _onError(err: Error) {
-
+        this._setError(err);
     }
 
     close(): Promise<void> {

--- a/src/devices/commandStations/websocket.ts
+++ b/src/devices/commandStations/websocket.ts
@@ -70,7 +70,9 @@ export class WebSocketCommandStation extends CommandStationBase {
     }
 
     close(): Promise<void> {
-        throw new Error("Method not implemented.");
+        this._setState(CommandStationState.SHUTTING_DOWN);
+        this._ws.close();
+        return this._untilState(CommandStationState.NOT_CONNECTED);
     }
 
     beginCommandBatch(): Promise<ICommandBatch> {

--- a/testdata/scripts/class159_start.txt
+++ b/testdata/scripts/class159_start.txt
@@ -1,0 +1,43 @@
+echo "Driver entering..."
+loco_function 159 18 on
+sleep 4
+loco_function 159 18 off
+sleep 3
+
+echo "Lights on!"
+loco_function 159 15 on
+sleep 2
+loco_function 159 0 on
+sleep 2
+
+echo "Starting engine..."
+loco_function 159 5 on
+loco_function 159 1 on
+sleep 15
+loco_function 159 5 off
+loco_function 159 7 on
+
+echo "Switching to day mode..."
+loco_function 159 14 on
+sleep 3
+
+echo "Passenger lights on!"
+loco_function 159 9 on
+sleep 4
+
+echo "Opening passenger doors..."
+loco_function 159 8 on
+sleep 15
+
+echo "All aboard!"
+loco_function 159 10
+sleep 2
+loco_function 159 8 off
+sleep 6
+
+echo "Ready?"
+loco_function 159 12 on
+sleep 3
+
+echo "Ready!"
+loco_function 159 12 off


### PR DESCRIPTION
Added a new WebSocket based command station that can send requests to a running Itokawa server.
Command station base can now be moved to an ERROR state with an explicit error.
Added support for rejecting promises if the command station is closed before it reaches a desired state.
Added utility functions to verify loco speed and function values.