### PR TITLE
Added support for variables in CLI scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itokawa",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itokawa",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "DCC Train Control",
   "private": true,
   "scripts": {

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -80,11 +80,16 @@ export function exec(context: CommandContext, args: string[]) {
                 return;
             }
 
-            const script = data.toString().split("\n");
-            for (const line of script)
-               await execCommand(context, line, true);
+            try {
+                const script = data.toString().split("\n");
+                for (const line of script)
+                    await execCommand(context, line, true);
 
-            resolve();
+                resolve();
+            }
+            catch (ex) {
+                reject(ex);
+            }
         });
     });
 }

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,5 +1,5 @@
 import { Logger, LogLevel } from "../utils/logger";
-import { resolveCommand, execCommand, CommandContext } from "./main"
+import { execCommand, CommandContext, error } from "./executor"
 import { timeout } from "../utils/promiseUtils";
 import * as fs from "fs";
 import { fromHex, toHumanHex } from "../utils/hex";
@@ -11,8 +11,8 @@ const _seenLocos = new Set<number>();
 
 function resolveLocoAddress(context: CommandContext, locoId: string): number {
     let address = parseInt(locoId);
-    if (isNaN(address)) context.error(`'${locoId}' is not a valid loco id`);
-    if (address < 1 || address > 9999) context.error(`'${locoId}' is not a valid loco id`)
+    if (isNaN(address)) error(`'${locoId}' is not a valid loco id`);
+    if (address < 1 || address > 9999) error(`'${locoId}' is not a valid loco id`)
 
     _seenLocos.add(address);
 
@@ -21,15 +21,15 @@ function resolveLocoAddress(context: CommandContext, locoId: string): number {
 
 function resolveSpeed(context: CommandContext, speedStr: string): number {
     let speed = parseInt(speedStr);
-    if (isNaN(speed)) context.error(`'${speedStr}' is not a valid speed value`);
-    if (speed < 0 || speed > 127) context.error(`'${speedStr}' is not a valid speed value`);
+    if (isNaN(speed)) error(`'${speedStr}' is not a valid speed value`);
+    if (speed < 0 || speed > 127) error(`'${speedStr}' is not a valid speed value`);
     return speed;
 }
 
 function resolveFunction(context: CommandContext, funcStr: string): number {
     let func = parseInt(funcStr);
-    if (isNaN(func)) context.error(`'${funcStr}' is not a valid function`);
-    if (func < 0 || func > 28) context.error(`'${funcStr}' is not a valid function`);
+    if (isNaN(func)) error(`'${funcStr}' is not a valid function`);
+    if (func < 0 || func > 28) error(`'${funcStr}' is not a valid function`);
     return func;
 }
 
@@ -61,7 +61,7 @@ echo.help = "Echo args back to the output."
 
 // Emergency stop
 export async function estop(context: CommandContext, args?: string[]) {
-    if (_seenLocos.size == 0) context.error("No locos have received commands yet.");
+    if (_seenLocos.size == 0) error("No locos have received commands yet.");
 
     const batch = await application.commandStation.beginCommandBatch();
     for (const address of _seenLocos) {
@@ -99,39 +99,15 @@ export async function exit(context: CommandContext, args?: string[]) {
 exit.maxArgs = 0;
 exit.help = "Exits this application";
 
-// Help
-export async function help(context: CommandContext, args: string[]) {
-    if (args.length == 0) {
-        context.out("Available commands:");
-        for (const commandName of Object.keys(exports)) {
-            try {
-                resolveCommand(context, commandName);
-                context.out(`  ${commandName}`);
-            }
-            catch {}
-        }
-        return;
-    }
-
-    const command = resolveCommand(context, args[0]);
-    if (!command) context.error(`Unrecognised command '${args[0]}'`);
-    if (!command.help) context.error(`${args[0]} is not helpful`);
-
-    const help = command.help instanceof Function ? command.help() : command.help;
-    context.out(help);
-}
-help.maxArgs = 1;
-help.help = "Lists available commands or retrieves help on a command\n  Usage: help [COMMAND_NAME]";
-
 function parseCvNumber(context: CommandContext, value: string) {
     const cv = parseInt(value);
-    if (isNaN(cv) || cv < 1 || cv > 255) context.error(`${value} is not a valid CV number`);
+    if (isNaN(cv) || cv < 1 || cv > 255) error(`${value} is not a valid CV number`);
     return cv;
 }
 
 function parseByte(context: CommandContext, value: string) {
     const byte = parseInt(value);
-    if (isNaN(byte) || byte < 0 || byte > 255) context.error(`${value} is not a valid byte value`);
+    if (isNaN(byte) || byte < 0 || byte > 255) error(`${value} is not a valid byte value`);
     return byte;
 }
 
@@ -196,7 +172,7 @@ export async function loglevel(context: CommandContext, args: string[]) {
     }
 
     const newLevel = args[0].toUpperCase();
-    if (!(newLevel in LogLevel)) context.error(`${newLevel} isn't a recognised log level`);
+    if (!(newLevel in LogLevel)) error(`${newLevel} isn't a recognised log level`);
 
     Logger.logLevel = LogLevel[newLevel];
 }
@@ -227,7 +203,7 @@ raw_write.help = "Write raw bytes to the command station\n  Udate: raw_write HEX
 // Sleep
 export async function sleep(context: CommandContext, args: string[]) {
     const time = parseFloat(args[0]);
-    if (isNaN(time)) context.error(`'${time}' is not a valid sleep duration`);
+    if (isNaN(time)) error(`'${time}' is not a valid sleep duration`);
 
     await timeout(time);
 }

--- a/src/cli/executor.spec.ts
+++ b/src/cli/executor.spec.ts
@@ -156,6 +156,33 @@ describe("Executor", () => {
         })
     })
 
+    describe("Variable Resolution", () => {
+        it("should resolve variables from the command context", async () => {
+            context.vars["foo"] = "Hello World";
+            executor.registerCommands(TEST_COMMANDS);
+            await executor.execCommand(context, "out Test $foo !", true);
+            expect(outStub.callCount).to.equal(3);
+            expect(errorStub.callCount).to.equal(0);
+            expect(outStub.getCall(0).args).to.eql(["Test"]);
+            expect(outStub.getCall(1).args).to.eql(["Hello World"]);
+            expect(outStub.getCall(2).args).to.eql(["!"]);
+        })
+
+        it("should raise error if variable not set", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await expect(executor.execCommand(context, "out Test $foo !")).to.be.eventually.rejectedWith("Variable 'foo' not set");
+            expect(outStub.callCount).to.equal(0);
+            expect(errorStub.callCount).to.equal(0);
+        })
+
+        it("should raise error if variable not specified", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await expect(executor.execCommand(context, "out Test $ !")).to.be.eventually.rejectedWith("Variable not specified");
+            expect(outStub.callCount).to.equal(0);
+            expect(errorStub.callCount).to.equal(0);
+        })
+    })
+
     describe("Error Handling", () => {
         it("should report command not found error when using execCommandSafe", async () => {
             await executor.execCommandSafe(context, "foo");

--- a/src/cli/executor.spec.ts
+++ b/src/cli/executor.spec.ts
@@ -1,0 +1,147 @@
+import { expect } from "chai";
+import "mocha";
+import { stub, SinonStub } from "sinon";
+import * as executor from "./executor"
+
+const TEST_COMMANDS: {[key: string]: executor.Command} = {
+    "out": (context: executor.CommandContext, params: string[]) => {
+        for (const param of params) context.out(param);
+        return Promise.resolve();
+    },
+    "error": (context: executor.CommandContext, params: string[]) => {
+        for (const param of params) context.error(param);
+        return Promise.resolve();
+    },
+    "throw": (context: executor.CommandContext, params: string[]) => {
+        throw Error(params[0]);
+    },
+    "ignore": (c, p) => Promise.resolve()
+}
+
+TEST_COMMANDS.throw.minArgs = 1;
+TEST_COMMANDS.throw.maxArgs = 1;
+TEST_COMMANDS.ignore.notCommand = true;
+
+
+describe("Executor", () => {
+    let context: executor.CommandContext = null;
+    let outStub: SinonStub = null;
+    let errorStub: SinonStub = null;
+
+    beforeEach(() => {
+        executor.clearCommands();
+        outStub = stub();
+        errorStub = stub();
+        context = {
+            out: outStub,
+            error: errorStub
+        };
+    })
+
+    describe("help", () => {
+        it("should be the only command registered by default", async () => {
+            await executor.execCommand(context, "help");
+            expect(outStub.callCount).to.equal(3);
+            expect(errorStub.callCount).to.equal(0);
+            expect(outStub.getCall(0).args).to.eql(["Available commands:"]);
+            expect(outStub.getCall(1).args).to.eql(["  help"]);
+            expect(outStub.getCall(2).args).to.eql(["OK"]);
+        })
+
+        it("should suppress 'OK' if requested", async () => {
+            await executor.execCommand(context, "help", true);
+            expect(outStub.callCount).to.equal(2);
+            expect(errorStub.callCount).to.equal(0);
+            expect(outStub.getCall(0).args).to.eql(["Available commands:"]);
+            expect(outStub.getCall(1).args).to.eql(["  help"]);
+        })
+
+        it("should list all registered valid commands alphabetically", async () => {
+            executor.registerCommands(TEST_COMMANDS, {
+                "foo": () => {},
+                "bar": () => {},
+                "not a command": "XXXX"
+            });
+            await executor.execCommand(context, "help", true);
+            expect(outStub.callCount).to.equal(7);
+            expect(errorStub.callCount).to.equal(0);
+            expect(outStub.getCall(0).args).to.eql(["Available commands:"]);
+            expect(outStub.getCall(1).args).to.eql(["  bar"]);
+            expect(outStub.getCall(2).args).to.eql(["  error"]);
+            expect(outStub.getCall(3).args).to.eql(["  foo"]);
+            expect(outStub.getCall(4).args).to.eql(["  help"]);
+            expect(outStub.getCall(5).args).to.eql(["  out"]);
+            expect(outStub.getCall(6).args).to.eql(["  throw"]);
+        })
+
+        it("should return the help for the specified command", async () => {
+            await executor.execCommand(context, "help help");
+            expect(outStub.callCount).to.equal(2);
+            expect(errorStub.callCount).to.equal(0);
+            expect(outStub.getCall(0).args).to.eql(["Lists available commands or retrieves help on a command\n  Usage: help [COMMAND_NAME]"]);
+            expect(outStub.getCall(1).args).to.eql(["OK"]);
+        })
+
+        it("should raise error if command is not registered", async () => {
+            await expect(executor.execCommand(context, "help foo")).to.be.eventually.rejectedWith("Unrecognised command 'foo'");
+        })
+
+        it("should raise error if command has no help", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await expect(executor.execCommand(context, "help out")).to.be.eventually.rejectedWith("out is not helpful");
+        })
+    })
+
+    describe("Error Handling", () => {
+        it("should report command not found error when using execCommandSafe", async () => {
+            await executor.execCommandSafe(context, "foo");
+            expect(outStub.callCount).to.equal(0);
+            expect(errorStub.callCount).to.equal(1);
+            expect(errorStub.lastCall.args).to.eql(["Unrecognised command 'foo'"]);
+        })
+
+        it("should raise a not found error when using execCommand", async () => {
+            await expect(executor.execCommand(context, "foo")).to.be.eventually.rejectedWith("Unrecognised command 'foo'");
+        })
+
+        it("should report command errors when using execCommandSafe", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await executor.execCommandSafe(context, 'throw "Test Error"');
+            expect(outStub.callCount).to.equal(0);
+            expect(errorStub.callCount).to.equal(1);
+            expect(errorStub.lastCall.args).to.eql(["Test Error"]);
+        })
+
+        it("should raise command errors when using execCommand", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await expect(executor.execCommand(context, 'throw "Test Error"')).to.be.eventually.rejectedWith("Test Error");
+        })
+
+        it("should not fail commands that produce error messages", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await executor.execCommand(context, "error a b c");
+            expect(outStub.callCount).to.equal(1);
+            expect(outStub.lastCall.args).to.eql(["OK"]);
+            expect(errorStub.callCount).to.equal(3);
+            expect(errorStub.getCall(0).args).to.eql(["a"]);
+            expect(errorStub.getCall(1).args).to.eql(["b"]);
+            expect(errorStub.getCall(2).args).to.eql(["c"]);
+        })
+
+        it("should reject commands with too few arguments", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await expect(executor.execCommand(context, 'throw')).to.be.eventually.rejectedWith("throw expects at least 1 args");
+        })
+
+        it("should reject commands with too many arguments", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await expect(executor.execCommand(context, 'throw foo bar')).to.be.eventually.rejectedWith("throw expects at most 1 args");
+        })
+
+        it("should ignore empty command strings", async () => {
+            await executor.execCommand(context, "    ");
+            expect(outStub.callCount).to.equal(0);
+            expect(errorStub.callCount).to.equal(0);
+        })
+    })
+})

--- a/src/cli/executor.spec.ts
+++ b/src/cli/executor.spec.ts
@@ -160,24 +160,25 @@ describe("Executor", () => {
         it("should resolve variables from the command context", async () => {
             context.vars["foo"] = "Hello World";
             executor.registerCommands(TEST_COMMANDS);
-            await executor.execCommand(context, "out Test $foo !", true);
-            expect(outStub.callCount).to.equal(3);
+            await executor.execCommand(context, 'out Test $foo "" !', true);
+            expect(outStub.callCount).to.equal(4);
             expect(errorStub.callCount).to.equal(0);
             expect(outStub.getCall(0).args).to.eql(["Test"]);
             expect(outStub.getCall(1).args).to.eql(["Hello World"]);
-            expect(outStub.getCall(2).args).to.eql(["!"]);
+            expect(outStub.getCall(2).args).to.eql([""]);
+            expect(outStub.getCall(3).args).to.eql(["!"]);
         })
 
         it("should raise error if variable not set", async () => {
             executor.registerCommands(TEST_COMMANDS);
-            await expect(executor.execCommand(context, "out Test $foo !")).to.be.eventually.rejectedWith("Variable 'foo' not set");
+            await expect(executor.execCommand(context, "out $foo")).to.be.eventually.rejectedWith("Variable 'foo' not set");
             expect(outStub.callCount).to.equal(0);
             expect(errorStub.callCount).to.equal(0);
         })
 
         it("should raise error if variable not specified", async () => {
             executor.registerCommands(TEST_COMMANDS);
-            await expect(executor.execCommand(context, "out Test $ !")).to.be.eventually.rejectedWith("Variable not specified");
+            await expect(executor.execCommand(context, "out $")).to.be.eventually.rejectedWith("Variable not specified");
             expect(outStub.callCount).to.equal(0);
             expect(errorStub.callCount).to.equal(0);
         })

--- a/src/cli/executor.spec.ts
+++ b/src/cli/executor.spec.ts
@@ -184,6 +184,46 @@ describe("Executor", () => {
         })
     })
 
+    describe("Comment Handling", () => {
+        it("should ignore comments", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await executor.execCommand(context, "out a b # c", true);
+            expect(outStub.callCount).to.equal(2);
+            expect(outStub.getCall(0).args).to.eql(["a"]);
+            expect(outStub.getCall(1).args).to.eql(["b"]);
+        })
+
+        it("should ignore comments attached to a variable", async () => {
+            context.vars["foo"] = "bar";
+            executor.registerCommands(TEST_COMMANDS);
+            await executor.execCommand(context, "out $foo# baz", true);
+            expect(outStub.callCount).to.equal(1);
+            expect(outStub.getCall(0).args).to.eql(["bar"]);
+        })
+
+        it("should not process variables for comments", async () => {
+            context.vars["foo"] = "# Hello World";
+            executor.registerCommands(TEST_COMMANDS);
+            await executor.execCommand(context, "out $foo", true);
+            expect(outStub.callCount).to.equal(1);
+            expect(outStub.getCall(0).args).to.eql(["# Hello World"]);
+        })
+
+        it("should not process comments in quotes", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await executor.execCommand(context, 'out "# foo"', true);
+            expect(outStub.callCount).to.equal(1);
+            expect(outStub.getCall(0).args).to.eql(["# foo"]);
+        })
+
+        it("should ignore comments preceded by a large number of spaces", async () => {
+            executor.registerCommands(TEST_COMMANDS);
+            await executor.execCommand(context, "out Test    \t\t# foo", true);
+            expect(outStub.callCount).to.equal(1);
+            expect(outStub.getCall(0).args).to.eql(["Test"]);
+        })
+    })
+
     describe("Error Handling", () => {
         it("should report command not found error when using execCommandSafe", async () => {
             await executor.execCommandSafe(context, "foo");

--- a/src/cli/executor.ts
+++ b/src/cli/executor.ts
@@ -1,0 +1,107 @@
+import { parseCommand } from "../utils/parsers";
+
+// Command function interface that specifies the available attributes
+type CommandFunc = (context: CommandContext, command:string[])=>Promise<void>;
+export interface Command extends CommandFunc {
+    notCommand?: boolean;           // Flag that the exported function is not a user command
+    minArgs?: number;               // Minimum number of args the user must supply
+    maxArgs?: number;               // Maximum number of args the user can supply
+    help?: () => string | string;   // String to display for command help
+}
+
+// Context used to allow commands to interact with their execution environment
+type Output = (message:string)=>void;
+export interface CommandContext {
+    out: Output;
+    error: Output;
+}
+
+// An exception a command can throw to display an error to the user without a call stack.
+// Should be used for user caused errors such as incorrectly specified args rather than actual failures.
+export class CommandError extends Error {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
+// Utility function to raise command errors of the correct type
+export function error(message: string) {
+    throw new CommandError(message);
+}
+
+const _commands = {};
+
+// Register commands with the executor
+export function registerCommands(...commandModules: any[]) {
+    for (const module of commandModules) {
+        for (const entry in module) {
+            const command = module[entry];
+            if (!(command instanceof Function)) continue;
+            if (command.notCommand) continue;
+            _commands[entry] = command;
+        }
+    }
+}
+
+// Handler for a raw command string which captures errors.
+export async function execCommandSafe(context: CommandContext, commandString: string, suppressOk: boolean=false) {
+    try {
+        await execCommand(context, commandString, suppressOk);
+    }
+    catch (ex) {
+        if (ex instanceof CommandError) context.error(ex.message);
+        else context.error(ex);
+    }
+}
+
+// Handler for a raw command string.
+export async function execCommand(context: CommandContext, commandString: string, suppressOk: boolean=false) {
+    const commandArgs = parseCommand(commandString);
+    if (commandArgs.length == 0) return;
+
+    const commandName = commandArgs.shift();
+    const command = resolveCommand(context, commandName);
+
+    if (typeof command.minArgs !== "undefined" && commandArgs.length < command.minArgs) error(`${commandName} expects at least ${command.minArgs} args`);
+    if (typeof command.maxArgs !== "undefined" && commandArgs.length > command.maxArgs) error(`${commandName} expects at most ${command.maxArgs} args`);
+
+    await command(context, commandArgs);
+    if (!suppressOk) context.out("OK");
+}
+
+// Return the function for the specified command.
+// If the command isn't found int the Commands exports or isn't a valid command function, an exception is raised
+export function resolveCommand(context: CommandContext, commandName: string): Command {
+    commandName = commandName.toLowerCase();
+    const command = _commands[commandName] as Command;
+    if (!command) error(`Unrecognised command '${commandName}'`);
+
+    return command;
+}
+
+
+//-----------------------------------------------------------------------------------------------//
+// Built in commands
+//-----------------------------------------------------------------------------------------------//
+
+// Help
+async function help(context: CommandContext, args: string[]) {
+    if (args.length == 0) {
+        context.out("Available commands:");
+        for (const commandName of Object.keys(_commands).sort()) {
+            context.out(`  ${commandName}`);
+        }
+        return;
+    }
+
+    const command = resolveCommand(context, args[0]);
+    if (!command) error(`Unrecognised command '${args[0]}'`);
+    if (!command.help) error(`${args[0]} is not helpful`);
+
+    const help = command.help instanceof Function ? command.help() : command.help;
+    context.out(help);
+}
+help.maxArgs = 1;
+help.help = "Lists available commands or retrieves help on a command\n  Usage: help [COMMAND_NAME]";
+
+_commands["help"] = help;

--- a/src/cli/executor.ts
+++ b/src/cli/executor.ts
@@ -30,12 +30,13 @@ export function error(message: string) {
     throw new CommandError(message);
 }
 
-let _commands = null;
+let _commands: {[ket:string]:Command} = null;
 
 export function clearCommands() {
     _commands = {}
     _commands["help"] = help;
     _commands["set"] = set;
+    _commands["unset"] = unset;
 }
 
 // Register commands with the executor
@@ -109,7 +110,7 @@ help.maxArgs = 1;
 help.help = "Lists available commands or retrieves help on a command\n  Usage: help [COMMAND_NAME]";
 
 // Set script variable
-function set(context: CommandContext, args: string[]) {
+async function set(context: CommandContext, args: string[]) {
     if (args.length === 0) {
         for (const key of Object.keys(context.vars).sort()) {
             context.out(`${key}=${context.vars[key]}`);
@@ -122,5 +123,14 @@ function set(context: CommandContext, args: string[]) {
 }
 set.maxArgs = 2;
 set.help = "Sets a script variable or lists all currently set variables\n  Usage: set [VARIABLE VALUE]";
+
+// Clear a script variable
+async function unset(context: CommandContext, args: string[]) {
+    if (!(args[0] in context.vars)) error(`'${args[0]}' is not set`);
+    delete context.vars[args[0]];
+}
+unset.minArgs = 1;
+unset.maxArgs = 1;
+unset.help = "Clear a script variable\n  Usage: set VARIABLE";
 
 clearCommands();

--- a/src/cli/executor.ts
+++ b/src/cli/executor.ts
@@ -73,6 +73,15 @@ export async function execCommand(context: CommandContext, commandString: string
     if (typeof command.minArgs !== "undefined" && commandArgs.length < command.minArgs) error(`${commandName} expects at least ${command.minArgs} args`);
     if (typeof command.maxArgs !== "undefined" && commandArgs.length > command.maxArgs) error(`${commandName} expects at most ${command.maxArgs} args`);
 
+    // Resolve variables
+    for (let i = 0; i < commandArgs.length; i++) {
+        if (commandArgs[i][0] !== '$') continue;
+        const variable = commandArgs[i].substr(1);
+        if (!variable) error("Variable not specified");
+        if (!(variable in context.vars)) error(`Variable '${variable}' not set`);
+        commandArgs[i] = context.vars[variable];
+    }
+
     await command(context, commandArgs);
     if (!suppressOk) context.out("OK");
 }

--- a/src/cli/executor.ts
+++ b/src/cli/executor.ts
@@ -14,6 +14,7 @@ type Output = (message:string)=>void;
 export interface CommandContext {
     out: Output;
     error: Output;
+    vars: {};
 }
 
 // An exception a command can throw to display an error to the user without a call stack.
@@ -34,6 +35,7 @@ let _commands = null;
 export function clearCommands() {
     _commands = {}
     _commands["help"] = help;
+    _commands["set"] = set;
 }
 
 // Register commands with the executor
@@ -105,5 +107,20 @@ async function help(context: CommandContext, args: string[]) {
 }
 help.maxArgs = 1;
 help.help = "Lists available commands or retrieves help on a command\n  Usage: help [COMMAND_NAME]";
+
+// Set script variable
+function set(context: CommandContext, args: string[]) {
+    if (args.length === 0) {
+        for (const key of Object.keys(context.vars).sort()) {
+            context.out(`${key}=${context.vars[key]}`);
+        }
+        return;
+    }
+
+    if (args.length === 1) error(`No value provided for '${args[0]}'`);
+    context.vars[args[0]] = args[1];
+}
+set.maxArgs = 2;
+set.help = "Sets a script variable or lists all currently set variables\n  Usage: set [VARIABLE VALUE]";
 
 clearCommands();

--- a/src/cli/executor.ts
+++ b/src/cli/executor.ts
@@ -32,6 +32,7 @@ export function error(message: string) {
 
 let _commands: {[ket:string]:Command} = null;
 
+// Clear out all additionally registered commands
 export function clearCommands() {
     _commands = {}
     _commands["help"] = help;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,11 +4,10 @@ import { Logger, LogLevel } from "../utils/logger";
 Logger.logLevel = LogLevel.DISPLAY;
 
 import { addCommonOptions } from "../utils/commandLineArgs";
-import { ICommandStation } from "../devices/commandStations/commandStation";
 import { nextTick } from "../utils/promiseUtils";
-import { parseCommand } from "../utils/parsers";
 import { toHumanHex } from "../utils/hex";
 import { application } from "../application";
+import * as executor from "./executor";
 
 // All commands are implemented as module level function exports and we discover then via "reflection"
 import * as Commands from "./commands";
@@ -20,32 +19,6 @@ program
     .option("-x --exec <script", "Execute a script")
     .option("--continue", "Continue to CLI after executing script or command");
 
-// Command function interface that specifies the available attributes
-type CommandFunc = (context: CommandContext, command:string[])=>Promise<void>;
-export interface Command extends CommandFunc {
-    notCommand?: boolean;           // Flag that the exported function is not a user command
-    minArgs?: number;               // Minimum number of args the user must supply
-    maxArgs?: number;               // Maximum number of args the user can supply
-    help?: () => string | string;   // String to display for command help
-}
-
-// Context used to allow commands to interact with their execution environment
-type Output = (message:string)=>void;
-export interface CommandContext {
-    out: Output;
-    error: Output;
-}
-
-// An exception a command can throw to display an error to the user without a call stack.
-// Should be used for user caused errors such as incorrectly specified args rather than actual failures.
-export class CommandError extends Error {
-    constructor(message: string) {
-        super(message);
-    }
-}
-
-let _commandContext: CommandContext = null;
-
 // Helper function for displaying command output to the user
 function _out(message: string) {
     console.log(message);
@@ -53,7 +26,7 @@ function _out(message: string) {
 
 // Helper function to throw a user error of the correct type
 function _error(message: string) {
-    throw new CommandError(message);
+    console.error(message);
 }
 
 // Handler for clean up when exit command is issued
@@ -65,50 +38,15 @@ async function _onExit() {
         });
     }
     catch(ex) {
-        if (!(ex instanceof CommandError)) {
+        if (!(ex instanceof executor.CommandError)) {
             console.error(ex.stack);
         }
     } 
 }
 
-// Handler for a raw command string.
-export async function execCommand(context: CommandContext, commandString: string, suppressOk: boolean=false) {
-    const commandArgs = parseCommand(commandString);
-    if (commandArgs.length == 0) return;
-
-    const commandName = commandArgs.shift();
-    const command = resolveCommand(context, commandName);
-
-    if (typeof command.minArgs !== "undefined" && commandArgs.length < command.minArgs) context.error(`${commandName} expects at least ${command.minArgs} args`);
-    if (typeof command.maxArgs !== "undefined" && commandArgs.length > command.maxArgs) context.error(`${commandName} expects at most ${command.maxArgs} args`);
-
-    await command(context, commandArgs);
-    if (!suppressOk) context.out("OK");
-}
-
-async function safeExec(exec: ()=>Promise<void>) {
-    try {
-        await exec();
-    }
-    catch (ex) {
-        if (ex instanceof CommandError) console.error(ex.message);
-        else console.error(ex);    
-    }
-}
-
-// Return the function for the specified command.
-// If the command isn't found int the Commands exports or isn't a valid command function, an exception is raised
-export function resolveCommand(context: CommandContext, commandName: string): Command {
-    commandName = commandName.toLowerCase();
-    const command = Commands[commandName] as Command;
-    if (!(command instanceof Function)) context.error(`Unrecognised command '${commandName}'`);
-    if (command.notCommand) context.error(`Unrecognised command '${commandName}'`);
-
-    return command;
-}
-
 async function main() {
     program.parse(process.argv);
+    executor.registerCommands(Commands);
 
     application.onshutdown = _onExit;
     await application.start(program);
@@ -124,19 +62,19 @@ async function main() {
     });
 
     // Set up the global context for command execution
-    _commandContext = {
+    const commandContext: executor.CommandContext = {
         out: _out,
         error: _error
     };
 
     // A command or script has been explicitly specified on the command line, so execute it and then exit
     if (program.cmd) {
-        await safeExec(() => execCommand(_commandContext, program.cmd, true));
-        if (!program.continue) await Commands.exit(_commandContext);
+        await executor.execCommandSafe(commandContext, program.cmd, true);
+        if (!program.continue) await Commands.exit(commandContext);
     }
     else if (program.exec) {
-        await safeExec(() => Commands.exec(_commandContext, [program.exec]));
-        if (!program.continue) await Commands.exit(_commandContext);
+        await executor.execCommandSafe(commandContext, `exec ${program.exec}`, true);
+        if (!program.continue) await Commands.exit(commandContext);
     }
 
     const rl = readline.createInterface({
@@ -154,7 +92,7 @@ async function main() {
 
         while (lineBuffer.length) {
             const line = lineBuffer.shift();
-            await safeExec(() => execCommand(_commandContext, line));
+            await executor.execCommandSafe(commandContext, line);
             await nextTick(); // Make sure other events have an opportunity to run between commands
         }
 
@@ -164,10 +102,8 @@ async function main() {
 
     rl.prompt();
     rl.on("line", (line) => {
-
         lineBuffer.push(line);
         proccessBufferedLines();
-
     }).on("close", () => {
         process.exit(0);
     });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -34,7 +34,8 @@ async function _onExit() {
     try {
         if (program.exitEstop) await Commands.estop({
             out: _out,
-            error: _error
+            error: _error,
+            vars: {}
         });
     }
     catch(ex) {
@@ -64,7 +65,8 @@ async function main() {
     // Set up the global context for command execution
     const commandContext: executor.CommandContext = {
         out: _out,
-        error: _error
+        error: _error,
+        vars: {}
     };
 
     // A command or script has been explicitly specified on the command line, so execute it and then exit

--- a/src/utils/parsers.spec.ts
+++ b/src/utils/parsers.spec.ts
@@ -144,6 +144,36 @@ describe("Parsers", () => {
             const result = parseCommand("\n\r\ta\t\r\nb\n\r\tc\r\n\t");
             expect(result).to.eql(["a", "b", "c"]);
         });
+
+        it("should handle line comments at beginning of line", () => {
+            const result = parseCommand("# Hello World");
+            expect(result).to.eql([]);
+        })
+
+        it("should handle line comments preceded by white space", () => {
+            const result = parseCommand("\t# Hello World");
+            expect(result).to.eql([]);
+        })
+
+        it("should handle line comments after valid text", () => {
+            const result = parseCommand("a b c # Hello World");
+            expect(result).to.eql(["a", "b", "c"]);
+        })
+
+        it("should handle line comments connected to valid characters", () => {
+            const result = parseCommand("abc# Hello World");
+            expect(result).to.eql(["abc"]);
+        })
+
+        it("should ignore comment character if it's quoted", () => {
+            const result = parseCommand("\"# Hello World\"");
+            expect(result).to.eql(["# Hello World"]);
+        })
+
+        it("should ignore comment character if it's escaped", () => {
+            const result = parseCommand("^# Hello World");
+            expect(result).to.eql(["#", "Hello", "World"]);
+        })
     });
 
     describe("Connection String Parser", () => {

--- a/src/utils/parsers.spec.ts
+++ b/src/utils/parsers.spec.ts
@@ -80,12 +80,27 @@ describe("Parsers", () => {
             expect(result).to.eql(["this is a quote: '\"'", "another\"quote"]);
         })
 
+        it("should preserve empty quoted strings", () => {
+            const result = parseCommand("a \"\" b");
+            expect(result).to.eql(["a", "", "b"]);
+        })
+
+        it("should handle empty quotes in middle of string", () => {
+            const result = parseCommand("a b\"\"c");
+            expect(result).to.eql(["a", "bc"]);
+        })
+
+        it("should parse strings with only empty quotes", () => {
+            const result = parseCommand("\"\"");
+            expect(result).to.eql([""]);
+        })
+
         it("should parse escaped hat", () => {
             const result = parseCommand("\"This is a hat: '^^'\" ^^");
             expect(result).to.eql(["This is a hat: '^'", "^"]);
         })
 
-        it("should parse any escaped chat", () => {
+        it("should parse any escaped char", () => {
             const result = parseCommand("^a^b^c^ ^d^e^f");
             expect(result).to.eql(["abc def"]);
         })

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -1,9 +1,10 @@
 const _whitespaceChars = new Set([" ", "\t", "\r", "\n", ""]);
 
-export function splitStringEx(text: string, splitChars: Set<string> | string[], quoteChar: string, escapeChar: string, preserveSpecials?: boolean): string[] {
+export function splitStringEx(text: string, splitChars: Set<string> | string[], quoteChar: string, escapeChar: string, preserveSpecials?: boolean, commentChar?: string): string[] {
     if (Array.isArray(splitChars)) splitChars = new Set(splitChars);
 
-    text = text || "";
+    text = text ?? "";
+    commentChar = commentChar ?? "";
     let commandArgs: string[] = [];
     let currentWord: string = null;
     let quoteMode: boolean = false;
@@ -17,11 +18,14 @@ export function splitStringEx(text: string, splitChars: Set<string> | string[], 
             if (preserveSpecials) currentWord += c;
             continue;
         }
-        if (c === escapeChar) {
+        else if (c === escapeChar) {
             isEscaped = true;
             i++;
             if (preserveSpecials) currentWord += c;
             c = text[i] || "";
+        }
+        else if (c === commentChar && !quoteMode) {
+            break;
         }
 
         if (splitChars.has(c) && !quoteMode && !isEscaped) {
@@ -54,7 +58,7 @@ export function parseFloatStrict(text: string): number {
 }
 
 export function parseCommand(command: string): string[] {
-    return splitStringEx(command, _whitespaceChars, "\"", "^");
+    return splitStringEx(command, _whitespaceChars, "\"", "^", false, "#");
 }
 
 export function parseConnectionString(c: string, fieldParsers?: {[key: string]: (arg:string) => any}): {[key: string]: any} {

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -5,7 +5,7 @@ export function splitStringEx(text: string, splitChars: Set<string> | string[], 
 
     text = text || "";
     let commandArgs: string[] = [];
-    let currentWord: string = "";
+    let currentWord: string = null;
     let quoteMode: boolean = false;
 
     for (let i = 0; i < text.length; i++) {
@@ -13,6 +13,7 @@ export function splitStringEx(text: string, splitChars: Set<string> | string[], 
         let c = text[i];
         if (c === quoteChar) {
             quoteMode = !quoteMode;
+            if (quoteMode) currentWord = currentWord ?? ""; // Allow empty quoted strings
             if (preserveSpecials) currentWord += c;
             continue;
         }
@@ -24,17 +25,18 @@ export function splitStringEx(text: string, splitChars: Set<string> | string[], 
         }
 
         if (splitChars.has(c) && !quoteMode && !isEscaped) {
-            if (currentWord) {
+            if (currentWord !== null) {
                 commandArgs.push(currentWord);
-                currentWord = "";
+                currentWord = null
             }    
         }
-        else {
+        else if (c) {
+            currentWord = currentWord ?? "";
             currentWord += c;
         }
     }
 
-    if (currentWord) commandArgs.push(currentWord);
+    if (currentWord !== null) commandArgs.push(currentWord);
 
     return commandArgs;
 }

--- a/testdata/scripts/class159_start.txt
+++ b/testdata/scripts/class159_start.txt
@@ -4,7 +4,7 @@
 set locoId 159
 
 echo "Driver entering..."
-loco_function $locoId 18 on         # Diver's door opem
+loco_function $locoId 18 on         # Driver's door opem
 sleep 4
 loco_function $locoId 18 off        # And closed
 sleep 3

--- a/testdata/scripts/class159_start.txt
+++ b/testdata/scripts/class159_start.txt
@@ -1,43 +1,45 @@
+set locoId 159
+
 echo "Driver entering..."
-loco_function 159 18 on
+loco_function $locoId 18 on
 sleep 4
-loco_function 159 18 off
+loco_function $locoId 18 off
 sleep 3
 
 echo "Lights on!"
-loco_function 159 15 on
+loco_function $locoId 15 on
 sleep 2
-loco_function 159 0 on
+loco_function $locoId 0 on
 sleep 2
 
 echo "Starting engine..."
-loco_function 159 5 on
-loco_function 159 1 on
+loco_function $locoId 5 on
+loco_function $locoId 1 on
 sleep 15
-loco_function 159 5 off
-loco_function 159 7 on
+loco_function $locoId 5 off
+loco_function $locoId 7 on
 
 echo "Switching to day mode..."
-loco_function 159 14 on
+loco_function $locoId 14 on
 sleep 3
 
 echo "Passenger lights on!"
-loco_function 159 9 on
+loco_function $locoId 9 on
 sleep 4
 
 echo "Opening passenger doors..."
-loco_function 159 8 on
+loco_function $locoId 8 on
 sleep 15
 
 echo "All aboard!"
-loco_function 159 10
+loco_function $locoId 10
 sleep 2
-loco_function 159 8 off
+loco_function $locoId 8 off
 sleep 6
 
 echo "Ready?"
-loco_function 159 12 on
+loco_function $locoId 12 on
 sleep 3
 
 echo "Ready!"
-loco_function 159 12 off
+loco_function $locoId 12 off

--- a/testdata/scripts/class159_start.txt
+++ b/testdata/scripts/class159_start.txt
@@ -1,45 +1,48 @@
+#
+# Start up sequence for sound fitted Bachmann Class 159
+#
 set locoId 159
 
 echo "Driver entering..."
-loco_function $locoId 18 on
+loco_function $locoId 18 on         # Diver's door opem
 sleep 4
-loco_function $locoId 18 off
+loco_function $locoId 18 off        # And closed
 sleep 3
 
 echo "Lights on!"
-loco_function $locoId 15 on
+loco_function $locoId 15 on         # Cab lights
 sleep 2
-loco_function $locoId 0 on
+loco_function $locoId 0 on          # Lights on
 sleep 2
 
 echo "Starting engine..."
-loco_function $locoId 5 on
-loco_function $locoId 1 on
+loco_function $locoId 5 on          # Cold start mode
+loco_function $locoId 1 on          # Sound on
 sleep 15
-loco_function $locoId 5 off
-loco_function $locoId 7 on
+loco_function $locoId 5 off         # Clear cold start
+loco_function $locoId 7 on          # Flange squeal
 
 echo "Switching to day mode..."
-loco_function $locoId 14 on
+loco_function $locoId 14 on         # Day lights on
 sleep 3
 
 echo "Passenger lights on!"
-loco_function $locoId 9 on
+loco_function $locoId 9 on          # Passenger cabin lights
 sleep 4
 
 echo "Opening passenger doors..."
-loco_function $locoId 8 on
+loco_function $locoId 8 on          # Open passenger doors
 sleep 15
 
 echo "All aboard!"
-loco_function $locoId 10
+loco_function $locoId 10            # Guard's whistle
 sleep 2
-loco_function $locoId 8 off
+loco_function $locoId 8 off         # Close the doors again
 sleep 6
 
 echo "Ready?"
-loco_function $locoId 12 on
+loco_function $locoId 12 on         # Buzzer check
 sleep 3
 
 echo "Ready!"
-loco_function $locoId 12 off
+loco_function $locoId 12 off        # Buzzer response


### PR DESCRIPTION
Added support for variables in command scripts. The variables are stored in the command context and can be accessed using the following:
* 'set' command to set a variable
* 'unset' to clear a variable
* '$VARNAME' to use a variable in a command, e.g. 'loco_speed $locoId 64'

Added support for line commends using '#'.
Fixed some parsing issues related to quoted empty strings.
Split command handling out into its own module so that it can be used outside of the CLI in the future.
Bumped version number to 0.3.2.