### PR TITLE
Added command station settings to config.xml

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,6 @@
             ],
             "program": "${workspaceFolder}/dist/server/main.js",
             "args": [
-                "-d", "NullCommandStation",
                 "--log-level", "debug"
             ],
         },
@@ -26,10 +25,8 @@
             ],
             "program": "${workspaceFolder}/dist/cli/main.js",
             "args": [
-                "--log-level",
-                "DEBUG",
-                "-x",
-                ".test.txt"
+                "--log-level", "debug",
+                "-x", ".test.txt"
             ],
         },
         {


### PR DESCRIPTION
Custom command station settings can now be included in config.xml, e.g.:
```
<config>
    <application>
        <commandStation>
            <device>WebSocketCommandStation</device>
            <connectionString>url=ws://itokawa:8080/control/v1</connectionString>
        </commandStation>
    </application>
</config>
```

Closes #62