### PR TITLE
#79 Moved command station monitor code into DeviceEnumerator

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -77,7 +77,6 @@ class Application {
         return this._db;
     }
 
-    private _args: CommanderStatic;
     private _config: ConfigNode = new ConfigNode();
     private _configPath: string;
     private _gitrev: string = "";
@@ -99,8 +98,6 @@ class Application {
     //  * Open the local database
     //  * Start the command station mointoring process
     async start(args: CommanderStatic, savepid: boolean = false): Promise<void> {
-        this._args = args;
-
         // We apply an initial log level based on the command line args so that we can debug
         // directory initialisation and config loading if needed
         applyLogLevel(args);

--- a/src/devices/asyncSerialPort.spec.ts
+++ b/src/devices/asyncSerialPort.spec.ts
@@ -88,6 +88,17 @@ describe("AsyncSerialPort", () => {
             expect(closeSpy.callCount).to.equal(1);
         });
 
+        it("should be safe to call multiple times", async () => {
+            let port = await open();
+            expect(closeSpy.callCount).to.equal(0);
+
+            await port.close();
+            await port.close();
+            await port.close();
+
+            expect(closeSpy.callCount).to.equal(1);
+        })
+
         it("should reject promise on error", async () => {
             closeSpy.restore();
             let closeMock = stub(MockBinding.prototype, "close");

--- a/src/devices/asyncSerialPort.ts
+++ b/src/devices/asyncSerialPort.ts
@@ -113,6 +113,11 @@ export class AsyncSerialPort extends EventEmitter {
     close(): Promise<void> {
         this._closeRequested = true;
         return new Promise((resolve, reject) => {
+            if (!this._port) {
+                resolve();
+                return;
+            }
+            
             _snapshotAdd("Close", this._port.path);
             this._port.close((err) => {
                 if (err) reject(err);

--- a/src/server/updater.ts
+++ b/src/server/updater.ts
@@ -11,7 +11,6 @@ const UPDATE_OS_COMMAND = "sudo apt-get update && sudo apt-get -y dist-upgrade"
 
 // Hooks to allow for testing so that tests that use global functions can overlap
 export let _spawnAsync = spawnAsync;
-export let _setTimeout = setTimeout;
 
 async function _runUpdate(command: string, operationId: string, send: (message: messages.CommandResponse)=>Promise<boolean>) {
     const endOperation = application.lifeCycle.beginSensitiveOperation(operationId);


### PR DESCRIPTION
Fix for `AsyncSerialPort.close()` throwing an exception if called multiple times.

Closes #79 