### PR TITLE
Added timeout support to AsyncSerialPort.read()

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,7 @@
             ],
             "program": "${workspaceFolder}/dist/cli/main.js",
             "args": [
-                "--log-level", "verbose",
+                "--log-level", "debug",
                 "-x", ".test.txt"
             ],
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,8 +25,9 @@
             ],
             "program": "${workspaceFolder}/dist/cli/main.js",
             "args": [
-                "--log-level", "debug",
-                "-x", ".test.txt"
+                "--log-level", "verbose",
+                "-d", "eLink", "-c", "port=COM3"
+                //"-x", ".test.txt"
             ],
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,8 +26,7 @@
             "program": "${workspaceFolder}/dist/cli/main.js",
             "args": [
                 "--log-level", "verbose",
-                "-d", "eLink", "-c", "port=COM3"
-                //"-x", ".test.txt"
+                "-x", ".test.txt"
             ],
         },
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itokawa",
-  "version": "0.4.1-dev",
+  "version": "0.4.2-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itokawa",
-  "version": "0.4.1-dev",
+  "version": "0.4.2-dev",
   "description": "DCC Train Control",
   "private": true,
   "scripts": {

--- a/src/devices/asyncSerialPort.spec.ts
+++ b/src/devices/asyncSerialPort.spec.ts
@@ -224,7 +224,7 @@ describe("AsyncSerialPort", () => {
             expect(setTimeoutStub.lastCall.args[1]).to.equal(500);
 
             setTimeoutStub.lastCall.args[0]();
-            expect(await promise).to.eql([]);
+            expect(await promise).to.be.null;
         })
 
         it("should reject if a port error is raised during a read", async () => {

--- a/src/devices/asyncSerialPort.spec.ts
+++ b/src/devices/asyncSerialPort.spec.ts
@@ -226,6 +226,25 @@ describe("AsyncSerialPort", () => {
             setTimeoutStub.lastCall.args[0]();
             expect(await promise).to.eql([]);
         })
+
+        it("should reject if a port error is raised during a read", async () => {
+            let port = await open();
+            port.on("error", stub());
+            let promise = port.read(1);
+
+            port["_port"].emit("error", new Error("Test Error"));
+
+            await expect(promise).to.be.eventually.rejectedWith("Test Error");
+        })
+
+        it("should reject if the port is closed during a read", async () => {
+            let port = await open();
+            port.on("error", stub());
+            let promise = port.read(1);
+            await port.close();
+
+            await expect(promise).to.be.eventually.rejectedWith("Port closed");
+        })
     });
 
     describe("concatRead", () => {

--- a/src/devices/asyncSerialPort.ts
+++ b/src/devices/asyncSerialPort.ts
@@ -95,12 +95,12 @@ export class AsyncSerialPort extends EventEmitter {
     read(size: number, timeoutSeconds?: number): Promise<number[]> {
         if (this._updateReader != _nullUpdate) return Promise.reject(new Error("Read already in progress"));
 
-        return new Promise<number[]>((resolve, reject) => {
+        return new Promise<number[]>((resolve) => {
             let timeoutToken = null;
             if (timeoutSeconds) {
                 timeoutToken = setTimeout(() => {
                     this._updateReader = _nullUpdate;
-                    reject(new Error("Read timeout"));
+                    resolve([]);
                 }, timeoutSeconds * 1000);
             }
             this._updateReader = () => {

--- a/src/devices/asyncSerialPort.ts
+++ b/src/devices/asyncSerialPort.ts
@@ -116,6 +116,7 @@ export class AsyncSerialPort extends EventEmitter {
                     resolve(null);
                 }, timeoutSeconds * 1000);
             }
+
             this._updateReader = () => {
                 if (this._buffer.length >= size) {
                     this._updateReader = _nullUpdate;

--- a/src/devices/asyncSerialPort.ts
+++ b/src/devices/asyncSerialPort.ts
@@ -34,6 +34,7 @@ export class AsyncSerialPort extends EventEmitter {
     private _closeRequested = false;
     private _buffer: number[] = [];
     private _updateReader: () => void = _nullUpdate;
+    private _rejects = new Set<(err: Error)=>void>();
 
     get bytesAvailable(): number {
         return this._buffer.length;
@@ -62,6 +63,7 @@ export class AsyncSerialPort extends EventEmitter {
             this._updateReader();
         });
         this._port.on("close", () => {
+            this._rejectOutstandingPromises(new Error("Port closed"));
             if (!this._closeRequested) {
                 log.warning("Serial port closed");
                 this.emit("error", new Error("Unexpected serial port close event"));
@@ -69,8 +71,16 @@ export class AsyncSerialPort extends EventEmitter {
         });
         this._port.on("error", (err) => {
             log.warning(`Serial port error: ${err}`);
+            this._rejectOutstandingPromises(err);
             this.emit("error", err);
         });
+    }
+
+    private _rejectOutstandingPromises(error: Error) {
+        log.debug(() => `Rejecting ${this._rejects.size} outstanding promises`);
+        for (const reject of this._rejects)
+            reject(error);
+        this._rejects.clear();
     }
 
     write(data: Buffer | number[]): Promise<void> {
@@ -95,11 +105,14 @@ export class AsyncSerialPort extends EventEmitter {
     read(size: number, timeoutSeconds?: number): Promise<number[]> {
         if (this._updateReader != _nullUpdate) return Promise.reject(new Error("Read already in progress"));
 
-        return new Promise<number[]>((resolve) => {
+        return new Promise<number[]>((resolve, reject) => {
+            this._rejects.add(reject);
+
             let timeoutToken = null;
             if (timeoutSeconds) {
                 timeoutToken = setTimeout(() => {
                     this._updateReader = _nullUpdate;
+                    this._rejects.delete(reject);
                     resolve([]);
                 }, timeoutSeconds * 1000);
             }
@@ -107,6 +120,7 @@ export class AsyncSerialPort extends EventEmitter {
                 if (this._buffer.length >= size) {
                     this._updateReader = _nullUpdate;
                     clearTimeout(timeoutToken);
+                    this._rejects.delete(reject);
                     resolve(this._buffer.splice(0, size));
                 }
             };

--- a/src/devices/asyncSerialPort.ts
+++ b/src/devices/asyncSerialPort.ts
@@ -113,7 +113,7 @@ export class AsyncSerialPort extends EventEmitter {
                 timeoutToken = setTimeout(() => {
                     this._updateReader = _nullUpdate;
                     this._rejects.delete(reject);
-                    resolve([]);
+                    resolve(null);
                 }, timeoutSeconds * 1000);
             }
             this._updateReader = () => {

--- a/src/devices/commandStations/elink.spec.ts
+++ b/src/devices/commandStations/elink.spec.ts
@@ -58,7 +58,7 @@ describe("eLink", () => {
                 return Promise.reject(new Error(`Unexpect port read in test, size=${size}`));
             }
             const data = portReads.shift();
-            if (data.length !== size && data.length !== 0) return Promise.reject(new Error(`Unexpected port read size in test, expected=${data.length}, actual=${size}`));
+            if (data !== null && data.length !== size) return Promise.reject(new Error(`Unexpected port read size in test, expected=${data.length}, actual=${size}`));
             return Promise.resolve(data);
         });
         serialPortStub.concatRead.callsFake(async (originalData, size) => {
@@ -125,9 +125,9 @@ describe("eLink", () => {
 
         it ("should retry 3 times if no info response is initially received", async () => {
             portReads = [
-                [],
-                [],
-                [],
+                null,
+                null,
+                null,
                 [0x01],
                 [0x02, 0x03],
                 [0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x35],
@@ -152,10 +152,10 @@ describe("eLink", () => {
 
         it ("should fail if no info response after the 3rd retry", async () => {
             portReads = [
-                [],
-                [],
-                [],
-                []
+                null,
+                null,
+                null,
+                null
             ];
 
             await expect(ELinkCommandStation.open(CONNECTION_STRING)).to.be.eventually.rejectedWith("No response from command station");
@@ -613,7 +613,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read
-                [],
+                null,
                 // CV value
                 [0x63],
                 [0x14, 0x01, 0x03, 0x75],
@@ -646,7 +646,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read,
-                [],
+                null,
                 // CV value
                 [0x63],
                 [0x14, 0x02, 0x03, 0x76],
@@ -680,7 +680,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read
-                [],
+                null,
                 // CV value
                 [0x63],
                 [0x14, 0x02, 0x13, 0x66],
@@ -715,7 +715,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read,
-                [],
+                null,
                 // CV value
                 [0x63],
                 [0x14, 0x08, 0x30, 0x4F],
@@ -765,7 +765,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read
-                [],
+                null,
                 // CV value
                 [0x61],
                 [0x13, 0x72]
@@ -787,7 +787,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read
-                [],
+                null,
                 // CV value
                 [0xFF]
             ]);
@@ -807,7 +807,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read
-                [],
+                null,
                 // CV value
                 [0x63],
                 [0x14, 0x02, 0x03, 0x76],
@@ -877,7 +877,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read
-                [],
+                null,
                 // CV value
                 [0x63],
                 [0x14, 0x01, 0x03, 0x70],
@@ -905,7 +905,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read
-                [],
+                null,
                 // CV value
                 [0x63],
                 [0x14, 0x01, 0x10, 0x66],
@@ -939,7 +939,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read
-                [],
+                null,
                 // CV value
                 [0x63],
                 [0x14, 0x01, 0x10, 0x66],
@@ -998,7 +998,7 @@ describe("eLink", () => {
                 [0x61, 0x01, 0x60],
                 [0x61, 0x01, 0x60],
                 // Time out read
-                [],
+                null,
                 [0x63],
                 [0x14, 0x01, 0x10, 0x66],
             ]);

--- a/src/devices/commandStations/elink.ts
+++ b/src/devices/commandStations/elink.ts
@@ -457,12 +457,21 @@ export class ELinkCommandStation extends CommandStationBase {
     }
 
     private async _sendStatusRequest() {
-        await this._port.write([MessageType.INFO_REQ, 0x24, 0x05]);
-        await this._disbatchResponse();
+        let retryCount = 3;
+        while (true) {
+            try {
+                await this._port.write([MessageType.INFO_REQ, 0x24, 0x05]);
+                await this._disbatchResponse();
+            }
+            catch (error) {
+                if (error.message !== "Read timeout" || retryCount-- === 0) throw error;
+                log.verbose("Timeout waiting for for status response, retrying...");
+            }
+        }
     }
 
     private async _disbatchResponse() {
-        let data = await this._port.read(1);
+        let data = await this._port.read(1, 3);
     
         switch (data[0])
         {

--- a/src/devices/commandStations/elink.ts
+++ b/src/devices/commandStations/elink.ts
@@ -260,7 +260,7 @@ export class ELinkCommandStation extends CommandStationBase {
         // We need to wait a bit and see if there are any more messages in the buffer before we can continue
         while (true) {
             resMessage = await this._port.read(3, 0.5);
-            if (resMessage.length === 0) break;
+            if (!resMessage) break;
             ensureValidMessage(resMessage, MessageType.CV_SELECT_RESPONSE);
             if (resMessage[1] !== 1) throw new Error(`Unexpected message: ${toHumanHex(resMessage)}`);
         }
@@ -465,7 +465,7 @@ export class ELinkCommandStation extends CommandStationBase {
 
     private async _disbatchResponse(): Promise<boolean> {
         let data = await this._port.read(1, 3);
-        if (data.length === 0) return false;
+        if (!data) return false;
     
         switch (data[0])
         {

--- a/src/devices/commandStations/elink.ts
+++ b/src/devices/commandStations/elink.ts
@@ -462,6 +462,7 @@ export class ELinkCommandStation extends CommandStationBase {
             try {
                 await this._port.write([MessageType.INFO_REQ, 0x24, 0x05]);
                 await this._disbatchResponse();
+                return;
             }
             catch (error) {
                 if (error.message !== "Read timeout" || retryCount-- === 0) throw error;

--- a/src/devices/commandStations/elink.ts
+++ b/src/devices/commandStations/elink.ts
@@ -259,12 +259,8 @@ export class ELinkCommandStation extends CommandStationBase {
         // The eLink is really annoying as we have no idea how many of these we'll receive, could be 3, could be 4
         // We need to wait a bit and see if there are any more messages in the buffer before we can continue
         while (true) {
-            // TODO - Add timeout support to reads
-            if (this._port.bytesAvailable === 0) {
-                await timeout(0.5);
-                if (this._port.bytesAvailable === 0) break;
-            }
-            resMessage = await this._port.read(3);
+            resMessage = await this._port.read(3, 0.5);
+            if (resMessage.length === 0) break;
             ensureValidMessage(resMessage, MessageType.CV_SELECT_RESPONSE);
             if (resMessage[1] !== 1) throw new Error(`Unexpected message: ${toHumanHex(resMessage)}`);
         }
@@ -459,20 +455,17 @@ export class ELinkCommandStation extends CommandStationBase {
     private async _sendStatusRequest() {
         let retryCount = 3;
         while (true) {
-            try {
-                await this._port.write([MessageType.INFO_REQ, 0x24, 0x05]);
-                await this._disbatchResponse();
-                return;
-            }
-            catch (error) {
-                if (error.message !== "Read timeout" || retryCount-- === 0) throw error;
-                log.verbose("Timeout waiting for for status response, retrying...");
-            }
+            await this._port.write([MessageType.INFO_REQ, 0x24, 0x05]);
+            const success = await this._disbatchResponse();
+            if (success) break;
+            if (retryCount-- === 0) throw new CommandStationError("No response from command station");
+            log.verbose("Timeout waiting for for status response, retrying...");
         }
     }
 
-    private async _disbatchResponse() {
+    private async _disbatchResponse(): Promise<boolean> {
         let data = await this._port.read(1, 3);
+        if (data.length === 0) return false;
     
         switch (data[0])
         {
@@ -489,6 +482,8 @@ export class ELinkCommandStation extends CommandStationBase {
             log.error(message);
             throw new CommandStationError(message);
         }
+
+        return true;
     }
 
     private async _handleHandshake(data: number[]) {


### PR DESCRIPTION
This is to enable me to use an Arduino device that resets when the serial port is opened.
Updated eLink to take advantage of read time outs for retry logic.