### PR TITLE
Removed node.js 12 support

### DIFF
--- a/.github/workflows/ci-node.js.yml
+++ b/.github/workflows/ci-node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Upgraded build pipeline to use node.js 18 instead of 17.